### PR TITLE
WIP: parameter optimization

### DIFF
--- a/delira/training/pytorch_trainer.py
+++ b/delira/training/pytorch_trainer.py
@@ -432,7 +432,7 @@ class PyTorchNetworkTrainer(AbstractNetworkTrainer):
 
         batchgen._finish()
 
-    def predict(self, batchgen, batch_size=None):
+    def _predict(self, batchgen, batch_size=None):
         """
         Returns predictions from network for batches from batchgen
 
@@ -517,7 +517,8 @@ class PyTorchNetworkTrainer(AbstractNetworkTrainer):
                     else:
                         loss_mean_vals[key] = val.detach()
 
-                outputs_all.append([pytorch_batch_to_numpy(tmp) for tmp in preds])
+                outputs_all.append([pytorch_batch_to_numpy(tmp)
+                                    for tmp in preds])
 
                 label_dict = {
                 }


### PR DESCRIPTION
rudimentary test script:

```python

import torch
from delira.training import PyTorchExperiment, Parameters
from delira.models import ClassificationNetworkBasePyTorch
from delira.data_loading import TorchvisionClassificationDataset, \
                                BaseDataManager
import numpy as np
from ray.tune import sample_from
from ray.tune.schedulers import AsyncHyperBandScheduler

sched = AsyncHyperBandScheduler(
    time_attr="training_iteration",
    reward_attr="neg_mean_loss",
    max_t=400,
    grace_period=20)

params = Parameters(
    fixed_params={
        "model": {
            "in_channels": 1, "n_outputs": 10},
        "training": {
            "batch_size": 1,  # batchsize to use
            "num_epochs": 10,  # number of epochs to train
            "optimizer_cls": torch.optim.Adam,  # optimization algorithm to use
            # initialization parameters for this algorithm
            "criterions": [torch.nn.CrossEntropyLoss()],  # the loss function
            "lr_sched_cls": None,  # the learning rate scheduling algorithm to use
            "lr_sched_params": {},  # the corresponding initialization parameters
            "metrics": []
            }
        },
    variable_params={
        "model": {},
        "training": {
            "optimizer_params": {
                'lr': sample_from(lambda spec: np.random.uniform(0.001, 0.1))
                }
            }
        }
    )

exp = PyTorchExperiment(params, model_cls=ClassificationNetworkBasePyTorch, gpu_ids=[0])

data_mgr_train = BaseDataManager(TorchvisionClassificationDataset("mnist",
                                                                    train=True),
                                params.fixed.training.batch_size,
                                n_process_augmentation=4,
                                transforms=None)

tune_config = {
        "stop": {
            "training_iteration": 1 
        },
        "resources_per_trial": {
            "cpu": 3
        },
        "num_samples": 5
        
    }

exp.tune_hyper_parameters(data_mgr_train, tune_config=tune_config,
                            trial_scheduler=sched ,params=params)



```