### PR TITLE
Undefined name: from torchvision.datasets import EMNIST

### DIFF
--- a/delira/data_loading/dataset.py
+++ b/delira/data_loading/dataset.py
@@ -551,7 +551,7 @@ class Nii3DCacheDatset(BaseCacheDataset):
 
 
 try:
-    from torchvision.datasets import CIFAR10, CIFAR100, MNIST, FashionMNIST
+    from torchvision.datasets import CIFAR10, CIFAR100, EMNIST, MNIST, FashionMNIST
 
     class TorchvisionClassificationDataset(AbstractDataset):
         """


### PR DESCRIPTION
https://pytorch.org/docs/stable/torchvision/datasets.html#emnist

[flake8](http://flake8.pycqa.org) testing of https://github.com/justusschock/delira on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./delira/data_loading/dataset.py:624:32: F821 undefined name 'EMNIST'
                _dataset_cls = EMNIST
                               ^
1     F821 undefined name 'EMNIST'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree