### PR TITLE
Remove image logging from closure

### DIFF
--- a/delira/models/classification/classification_network.py
+++ b/delira/models/classification/classification_network.py
@@ -160,9 +160,6 @@ if "TORCH" in get_backends():
                                         "env_appendix": "_%02d" % fold
                                         }})
 
-            logging.info({'image_grid': {"images": inputs, "name": "input_images",
-                                         "env_appendix": "_%02d" % fold}})
-
             return metric_vals, loss_vals, [preds]
 
         @staticmethod

--- a/delira/models/gan/generative_adversarial_network.py
+++ b/delira/models/gan/generative_adversarial_network.py
@@ -227,11 +227,11 @@ if "TORCH" in get_backends():
                                         "env_appendix": "_%02d" % fold
                                         }})
 
-            logging.info({'image_grid': {"images": batch, "name": "real_images",
-                                        "env_appendix": "_%02d" % fold}})
-            logging.info({"image_grid": {"images": fake_image_batch,
-                                        "name": "fake_images",
-                                        "env_appendix": "_%02d" % fold}})
+#             logging.info({'image_grid': {"images": batch, "name": "real_images",
+#                                         "env_appendix": "_%02d" % fold}})
+#             logging.info({"image_grid": {"images": fake_image_batch,
+#                                         "name": "fake_images",
+#                                         "env_appendix": "_%02d" % fold}})
 
             return metric_vals, loss_vals, [fake_image_batch, discr_pred_fake,
                                             discr_pred_real]

--- a/delira/models/segmentation/unet.py
+++ b/delira/models/segmentation/unet.py
@@ -269,13 +269,6 @@ if "TORCH" in get_backends():
                                         "env_appendix": "_%02d" % fold
                                         }})
 
-            logging.info({'image_grid': {"images": inputs, "name": "input_images",
-                                        "env_appendix": "_%02d" % fold}})
-
-            logging.info({'image_grid': {"images": preds,
-                                        "name": "predicted_images",
-                                        "env_appendix": "_%02d" % fold}})
-
             return metric_vals, loss_vals, [preds]
 
         def _build_model(self, num_classes, in_channels=3, depth=5,
@@ -720,18 +713,6 @@ if "TORCH" in get_backends():
                 logging.info({"value": {"value": val.item(), "name": key,
                                         "env_appendix": "_%02d" % fold
                                         }})
-
-            slicing_dim = inputs.size(2) // 2  # visualize slice in mid of volume
-
-            logging.info({'image_grid': {"inputs": inputs[:, :, slicing_dim, ...],
-                                        "name":
-                                            "input_images",
-                                        "env_appendix": "_%02d" % fold}})
-
-            logging.info({'image_grid': {"results": preds[:, :, slicing_dim, ...],
-                                        "name":
-                                            "predicted_images",
-                                        "env_appendix": "_%02d" % fold}})
 
             return metric_vals, loss_vals, [preds]
 


### PR DESCRIPTION
Since the logging API of `trixi` changed regarding the image logging, we should only log scalars here per default