### PR TITLE
Move to new APEX.amp API

### DIFF
--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -134,6 +134,7 @@ class AbstractNetwork(object):
         """
         return self._init_kwargs
 
+
 if "TORCH" in get_backends():
     import torch
 

--- a/delira/models/classification/classification_network.py
+++ b/delira/models/classification/classification_network.py
@@ -9,6 +9,9 @@ if "TORCH" in get_backends():
     from torchvision import models as t_models
     from delira.models.abstract_network import AbstractPyTorchNetwork
 
+    # use loss scaling if installed, otherwise falls back to "normal" backward
+    from ..model_utils import scale_loss
+
     class ClassificationNetworkBasePyTorch(AbstractPyTorchNetwork):
         """
         Implements basic classification with ResNet18
@@ -140,7 +143,8 @@ if "TORCH" in get_backends():
             if optimizers:
                 optimizers['default'].zero_grad()
                 # perform loss scaling via apex if half precision is enabled
-                with optimizers["default"].scale_loss(total_loss) as scaled_loss:
+                with scale_loss(total_loss,
+                                optimizers["default"]) as scaled_loss:
                     scaled_loss.backward()
                 optimizers['default'].step()
 

--- a/delira/models/gan/generative_adversarial_network.py
+++ b/delira/models/gan/generative_adversarial_network.py
@@ -6,8 +6,9 @@ from delira.utils.decorators import make_deprecated
 
 if "TORCH" in get_backends():
     import torch
-    from torchvision import models as t_models
 
+    # use loss scaling if installed, otherwise falls back to "normal" backward
+    from ..model_utils import scale_loss
     from delira.models.abstract_network import AbstractPyTorchNetwork
 
 
@@ -175,8 +176,8 @@ if "TORCH" in get_backends():
                     optimizers["discr"].zero_grad()
                     # perform loss scaling via apex if mixed precision is 
                     # enabled
-                    with optimizers["discr"].scale_loss(
-                            total_loss_discr) as scaled_loss:
+                    with scale_loss(total_loss_discr,
+                                    optimizers["discr"]) as scaled_loss:
                         scaled_loss.backward(retain_graph=True)
                     optimizers["discr"].step()
 
@@ -213,8 +214,8 @@ if "TORCH" in get_backends():
                     # actual backpropagation
                     optimizers["gen"].zero_grad()
                     # perform loss scaling via apex if half precision is enabled
-                    with optimizers["gen"].scale_loss(
-                            total_loss_gen) as scaled_loss:
+                    with scale_loss(total_loss_gen,
+                                    optimizers["gen"]) as scaled_loss:
                         scaled_loss.backward()
                     optimizers["gen"].step()
 

--- a/delira/models/model_utils.py
+++ b/delira/models/model_utils.py
@@ -1,0 +1,26 @@
+import contextlib
+
+try:
+    # use apex loss scaling if possible
+    # (and enabled, this is done internally by apex)
+    from apex import amp
+except ImportError:
+    # use no loss scaling with same API if apex is unavailable
+    amp = None
+
+
+@contextlib.contextmanager
+def scale_loss(loss,
+               optimizers,
+               loss_id=0,
+               model=None,
+               delay_unscale=False):
+    if amp is None:
+        yield loss
+
+    else:
+        with amp.scale_loss(loss=loss, optimizers=optimizers,
+                            loss_id=loss_id, model=model,
+                            delay_unscale=delay_unscale) as _loss:
+            yield _loss
+    return

--- a/delira/models/model_utils.py
+++ b/delira/models/model_utils.py
@@ -14,13 +14,15 @@ def scale_loss(loss,
                optimizers,
                loss_id=0,
                model=None,
-               delay_unscale=False):
+               delay_unscale=False,
+               **kwargs):
     if amp is None:
         yield loss
 
     else:
         with amp.scale_loss(loss=loss, optimizers=optimizers,
                             loss_id=loss_id, model=model,
-                            delay_unscale=delay_unscale) as _loss:
+                            delay_unscale=delay_unscale, 
+                            **kwargs) as _loss:
             yield _loss
     return

--- a/delira/models/segmentation/unet.py
+++ b/delira/models/segmentation/unet.py
@@ -9,6 +9,8 @@ if "TORCH" in get_backends():
     from torch.nn import init
     import logging
     from ..abstract_network import AbstractPyTorchNetwork
+    # use loss scaling if installed, otherwise falls back to "normal" backward
+    from ..model_utils import scale_loss
 
     class UNet2dPyTorch(AbstractPyTorchNetwork):
         """
@@ -248,7 +250,8 @@ if "TORCH" in get_backends():
             if optimizers:
                 optimizers['default'].zero_grad()
                 # perform loss scaling via apex if half precision is enabled
-                with optimizers["default"].scale_loss(total_loss) as scaled_loss:
+                with scale_loss(total_loss,
+                                optimizers["default"]) as scaled_loss:
                     scaled_loss.backward()
                 optimizers['default'].step()
 
@@ -689,7 +692,8 @@ if "TORCH" in get_backends():
             if optimizers:
                 optimizers['default'].zero_grad()
                 # perform loss scaling via apex if half precision is enabled
-                with optimizers["default"].scale_loss(total_loss) as scaled_loss:
+                with scale_loss(total_loss,
+                                optimizers["default"]) as scaled_loss:
                     scaled_loss.backward()
                 optimizers['default'].step()
 

--- a/delira/training/predictor.py
+++ b/delira/training/predictor.py
@@ -70,7 +70,7 @@ class Predictor(object):
         convert_batch_to_npy_fn : type
             a callable function to convert tensors in positional and keyword
             arguments to numpy
-        prepare_batch_fn : type
+        prepare_batch_fn : (dict, str, str) -> dict
             function converting a batch-tensor to the framework specific
             tensor-type and pushing it to correct device, default: identity
             function

--- a/delira/training/pytorch_trainer.py
+++ b/delira/training/pytorch_trainer.py
@@ -52,9 +52,14 @@ if "TORCH" in get_backends():
                      metric_keys=None,
                      convert_batch_to_npy_fn=convert_torch_tensor_to_npy,
                      mixed_precision=False,
-                     mixed_precision_kwargs={"enable_caching": True,
-                                             "verbose": False,
-                                             "allow_banned": False},
+                     mixed_precision_kwargs={"opt_level": "o0",
+                                             "cast_model_type": None,
+                                             "patch_torch_functions": None,
+                                             "master_weights": None,
+                                             "loss_scale": None,
+                                             "cast_model_outputs": None,
+                                             "num_losses": 1,
+                                             "verbosity": 1},
                      criterions=None,
                      val_freq=1,
                      ** kwargs):
@@ -120,6 +125,50 @@ if "TORCH" in get_backends():
                 whether to use mixed precision or not (False per default)
             mixed_precision_kwargs : dict
                 additional keyword arguments for mixed precision
+                from https://github.com/NVIDIA/apex/blob/master/apex/amp/frontend.py:
+                    opt_level : str
+                        Pure or mixed precision optimization level. Accepted
+                        values are "O0", "O1", "O2", and "O3":
+                            O0:  Pure FP32 training.
+                            O1:  Insert automatic casts around Pytorch functions
+                                and Tensor methods.
+                            O2:  FP16 training with FP32 batchnorm and FP32
+                                master weights
+                            O3:  Pure FP16 training.
+
+                    cast_model_type : :class:`torch.dtype`
+                        Optional property override for model dtype;
+                        default: None
+                    patch_torch_functions : bool
+                        Optional property override.
+                    keep_batchnorm_fp32 : bool or str
+                        Optional property override.  If passed as a string,
+                        must be the string "True" or "False".
+                    master_weights : bool
+                        Optional property override; whether to create master
+                        weights or not
+                    loss_scale : float or str
+                        Optional property override.  If passed as a string,
+                        must be a string representing a number, e.g., "128.0",
+                        or the string "dynamic".
+                    cast_model_outputs : :class:`torch.dtype`
+                        Option to ensure that the outputs of your model(s)
+                        are always cast to a particular type regardless
+                        of ``opt_level``.
+                    num_losses : int
+                        Option to tell Amp in advance how many losses/backward
+                        passes you plan to use.  When used in conjunction with
+                        the ``loss_id`` argument to ``amp.scale_loss``, enables
+                        Amp to use a different loss scale per loss/backward
+                        pass, which can improve stability. See
+                        "Multiple models/optimizers/losses" under
+                        "Advanced Amp Usage" for examples.  If ``num_losses``
+                        is left to 1, Amp will still support multiple
+                        losses/backward passes, but use a single global
+                        loss scale for all of them; default: 1
+                    verbosity : int
+                        Set to 0 to suppress Amp-related output; default: 1
+
             val_freq : int
                 validation frequency specifying how often to validate the trained
                 model (a value of 1 denotes validating every epoch,
@@ -152,7 +201,7 @@ if "TORCH" in get_backends():
                 network, save_path, crits, optimizer_cls, optimizer_params,
                 train_metrics, val_metrics, lr_scheduler_cls,
                 lr_scheduler_params, gpu_ids, save_freq, optim_fn, key_mapping,
-                logging_type, logging_kwargs, fold, callbacks, start_epoch, 
+                logging_type, logging_kwargs, fold, callbacks, start_epoch,
                 metric_keys, convert_batch_to_npy_fn, val_freq)
 
             self._setup(network, optim_fn, optimizer_cls, optimizer_params,
@@ -200,25 +249,6 @@ if "TORCH" in get_backends():
             super()._setup(network, lr_scheduler_cls, lr_scheduler_params,
                            gpu_ids, key_mapping, convert_batch_to_npy_fn,
                            network.prepare_batch)
-
-            try:
-                from apex import amp
-                self._amp_handle = amp.init(mixed_precision,
-                                            *mixed_precision_kwargs)
-                wrap_fn = self._amp_handle.wrap_optimizer
-
-            except ImportError:
-                if mixed_precision:
-                    logger.warning("Apex was not found found, trying to \
-                                    continue in full precision instead")
-                from ..utils.context_managers import DefaultOptimWrapperTorch
-                wrap_fn = DefaultOptimWrapperTorch
-
-            # wrap optimizers by half_precision_optimizer via apex if 
-            # necessary
-            self.optimizers = {k: wrap_fn(
-                v, num_loss=len(self.losses)) for k, v
-                in self.optimizers.items()}
 
             # Load latest epoch file if available
             if os.path.isdir(self.save_path):
@@ -285,6 +315,28 @@ if "TORCH" in get_backends():
                 self._prepare_batch, input_device=self.input_device,
                 output_device=self.output_device)
 
+            try:
+                # use apex for mixed precision if installed
+                from apex import amp
+
+                # extract optimizers and corresponding keys
+                # (in case dict is not ordered)
+                _optim_keys = list(self.optimizers.keys())
+                _optims = list(self.optimizers[k] for k in _optim_keys)
+
+                # wrap model and register optimizers for mixed precision
+                self.module, _optims = amp.initialize(self.module, _optims,
+                                                      mixed_precision,
+                                                      **mixed_precision_kwargs)
+                for k, v in zip(_optim_keys, _optims):
+                    self.optimizers[k] = v
+
+            except (ImportError, RuntimeError) as e:
+                logging.debug("Either APEX can't be imported correctly or a value "
+                              "missmatch occured. Switching to default FP32 "
+                              "training insted. The following Exception occured:"
+                              "\n%s" % str(e))
+
         def _at_training_begin(self, *args, **kwargs):
             """
             Defines behaviour at beginning of training
@@ -311,7 +363,7 @@ if "TORCH" in get_backends():
                 best network
 
             """
-            if os.path.isfile(os.path.join(self.save_path, 
+            if os.path.isfile(os.path.join(self.save_path,
                                            'checkpoint_best.pt')):
 
                 # load best model and return it
@@ -374,7 +426,7 @@ if "TORCH" in get_backends():
 
             self.module.train()
 
-            return super()._train_single_epoch(batchgen, epoch, 
+            return super()._train_single_epoch(batchgen, epoch,
                                                verbose=verbose)
 
         def predict_data_mgr(self, datamgr, batchsize=None, metrics={},

--- a/delira/training/pytorch_trainer.py
+++ b/delira/training/pytorch_trainer.py
@@ -52,7 +52,7 @@ if "TORCH" in get_backends():
                      metric_keys=None,
                      convert_batch_to_npy_fn=convert_torch_tensor_to_npy,
                      mixed_precision=False,
-                     mixed_precision_kwargs={"opt_level": "o0",
+                     mixed_precision_kwargs={"opt_level": "o1",
                                              "cast_model_type": None,
                                              "patch_torch_functions": None,
                                              "master_weights": None,

--- a/delira/utils/context_managers.py
+++ b/delira/utils/context_managers.py
@@ -1,6 +1,7 @@
 import contextlib
 
 from delira import get_backends
+from .decorators import make_deprecated
 
 if "TORCH" in get_backends():
     import torch
@@ -12,6 +13,8 @@ if "TORCH" in get_backends():
 
         """
 
+        @make_deprecated("'delira.models.model_utils.scale_loss' combined with "
+                         "new apex.amp API (https://github.com/NVIDIA/apex)")
         def __init__(self, optimizer: torch.optim.Optimizer, *args, **kwargs):
             """
 


### PR DESCRIPTION
Closes #71 

Re-Enables current (unified and more stable) AMP API.

Apex must still be installed manually and following [this PR](https://github.com/NVIDIA/apex/pull/252) it's mixed precision training currently only works on GPU.

EDIT: Switched base branch to not intermingle this with trainer refactoring