### PR TITLE
Update batchgenerators requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ tqdm
 visdom>=0.1.8.5
 pyyaml
 trixi-slim
-batchgenerators>=0.18.2,!=0.19.2,!=0.19
+batchgenerators>=0.18.2,!=0.19.2
 psutil
 nested_lookup

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ tqdm
 visdom>=0.1.8.5
 pyyaml
 trixi-slim
-batchgenerators==0.18.2
+batchgenerators>=0.18.2,!=0.19.2,!=0.19
 psutil
 nested_lookup


### PR DESCRIPTION
Exclude 0.19.2 to avoid build failures.

Fix #89 