### PR TITLE
Scikit-Learn Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,24 @@ language: python
 
 matrix:
     include:
+        - name: "Unittests Python 3.5 Sklearn Backend"
+          python: 3.5
+          dist: xenial
+          env:
+              - TEST_TYPE="unittests"
+              - BACKEND="Sklearn"
+        - name: "Unittests Python 3.6 Sklearn Backend"
+          python: 3.6
+          dist: xenial
+          env:
+              - TEST_TYPE="unittests"
+              - BACKEND="Sklearn"
+        - name: "Unittests Python 3.7 Sklearn Backend"
+          python: 3.7
+          dist: xenial
+          env:
+              - TEST_TYPE="unittests"
+              - BACKEND="Sklearn"
         - name: "Unittests Python 3.5 TF Backend"
           python: 3.5
           dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_install:
     - if [[ "$TEST_TYPE" == "unittests" ]]; then
           bash scripts/ci/install_before_tests.sh;
       elif [[ "$TEST_TYPE" == "docs" ]]; then
-          bash scripts/ci/install_before_docs.sh
+          bash scripts/ci/install_before_docs.sh;
       else
           bash scripts/ci/install_before_style_check.sh;
       fi

--- a/delira/__init__.py
+++ b/delira/__init__.py
@@ -6,13 +6,44 @@ import warnings
 warnings.simplefilter('default', DeprecationWarning)
 warnings.simplefilter('ignore', ImportWarning)
 
-# to register new pssible backends, they have to be added to this list.
+# to register new possible backends, they have to be added to this list.
 # each backend should consist of a tuple of length 2 with the first entry
 # being the package import name and the second being the backend abbreviation.
 # E.g. TensorFlow's package is named 'tensorflow' but if the package is found,
 # it will be considered as 'tf' later on
-__POSSIBLE_BACKENDS = [("torch", "torch"), ("tensorflow", "tf")]
+__POSSIBLE_BACKENDS = [("torch", "torch"), ("tensorflow", "tf"),
+                       ("sklearn", "sklearn")]
 __BACKENDS = []
+
+
+def _update_backends(config_file):
+    _backends = {}
+    # try to import all possible backends to determine valid backends
+
+    import importlib
+    for curr_backend in __POSSIBLE_BACKENDS:
+        try:
+            assert len(curr_backend) == 2
+            assert all([isinstance(_tmp, str) for _tmp in curr_backend]), \
+                "All entries in current backend must be strings"
+
+            # check if backend can be imported
+            bcknd = importlib.util.find_spec(curr_backend[0])
+
+            if bcknd is not None:
+                _backends[curr_backend[1]] = True
+            else:
+                _backends[curr_backend[1]] = False
+            del bcknd
+
+        except ValueError:
+            _backends[curr_backend[1]] = False
+
+    with open(config_file, "w") as f:
+        json.dump({"version": __version__, "backend": _backends},
+                  f, sort_keys=True, indent=4)
+
+    del _backends
 
 
 def _determine_backends():
@@ -22,33 +53,7 @@ def _determine_backends():
     # if file exists: load config into environment variables
 
     if not os.path.isfile(_config_file):
-        _backends = {}
-        # try to import all possible backends to determine valid backends
-
-        import importlib
-        for curr_backend in __POSSIBLE_BACKENDS:
-            try:
-                assert len(curr_backend) == 2
-                assert all([isinstance(_tmp, str) for _tmp in curr_backend]), \
-                    "All entries in current backend must be strings"
-
-                # check if backend can be imported
-                bcknd = importlib.util.find_spec(curr_backend[0])
-
-                if bcknd is not None:
-                    _backends[curr_backend[1]] = True
-                else:
-                    _backends[curr_backend[1]] = False
-                del bcknd
-
-            except ValueError:
-                _backends[curr_backend[1]] = False
-
-        with open(_config_file, "w") as f:
-            json.dump({"version": __version__, "backend": _backends},
-                      f, sort_keys=True, indent=4)
-
-        del _backends
+        _update_backends(_config_file)
 
     # set values from config file to variable
     with open(_config_file) as f:
@@ -61,6 +66,23 @@ def _determine_backends():
     del _config_file
 
 
+def update_backends():
+    """
+    Updates all installed backends (and deletes old backend-configuration file)
+
+    Returns
+    -------
+
+    """
+    _config_file = __file__.replace("__init__.py", ".delira")
+    _BACKENDS = []
+
+    if os.path.isfile(_config_file):
+        os.remove(_config_file)
+
+    return get_backends()
+
+
 def get_backends():
     """
     Return List of currently available backends
@@ -68,7 +90,7 @@ def get_backends():
     Returns
     -------
     list
-        list of strings containing the currently installed backends
+        list of strings indicating all currently installed backends
 
     """
 

--- a/delira/__init__.py
+++ b/delira/__init__.py
@@ -10,13 +10,44 @@ import warnings
 warnings.simplefilter('default', DeprecationWarning)
 warnings.simplefilter('ignore', ImportWarning)
 
-# to register new pssible backends, they have to be added to this list.
+# to register new possible backends, they have to be added to this list.
 # each backend should consist of a tuple of length 2 with the first entry
 # being the package import name and the second being the backend abbreviation.
 # E.g. TensorFlow's package is named 'tensorflow' but if the package is found,
 # it will be considered as 'tf' later on
-__POSSIBLE_BACKENDS = [("torch", "torch"), ("tensorflow", "tf")]
+__POSSIBLE_BACKENDS = [("torch", "torch"), ("tensorflow", "tf"),
+                       ("sklearn", "sklearn")]
 __BACKENDS = []
+
+
+def _update_backends(config_file):
+    _backends = {}
+    # try to import all possible backends to determine valid backends
+
+    import importlib
+    for curr_backend in __POSSIBLE_BACKENDS:
+        try:
+            assert len(curr_backend) == 2
+            assert all([isinstance(_tmp, str) for _tmp in curr_backend]), \
+                "All entries in current backend must be strings"
+
+            # check if backend can be imported
+            bcknd = importlib.util.find_spec(curr_backend[0])
+
+            if bcknd is not None:
+                _backends[curr_backend[1]] = True
+            else:
+                _backends[curr_backend[1]] = False
+            del bcknd
+
+        except ValueError:
+            _backends[curr_backend[1]] = False
+
+    with open(config_file, "w") as f:
+        json.dump({"version": __version__, "backend": _backends},
+                  f, sort_keys=True, indent=4)
+
+    del _backends
 
 
 def _determine_backends():
@@ -26,33 +57,7 @@ def _determine_backends():
     # if file exists: load config into environment variables
 
     if not os.path.isfile(_config_file):
-        _backends = {}
-        # try to import all possible backends to determine valid backends
-
-        import importlib
-        for curr_backend in __POSSIBLE_BACKENDS:
-            try:
-                assert len(curr_backend) == 2
-                assert all([isinstance(_tmp, str) for _tmp in curr_backend]), \
-                    "All entries in current backend must be strings"
-
-                # check if backend can be imported
-                bcknd = importlib.util.find_spec(curr_backend[0])
-
-                if bcknd is not None:
-                    _backends[curr_backend[1]] = True
-                else:
-                    _backends[curr_backend[1]] = False
-                del bcknd
-
-            except ValueError:
-                _backends[curr_backend[1]] = False
-
-        with open(_config_file, "w") as f:
-            json.dump({"version": __version__, "backend": _backends},
-                      f, sort_keys=True, indent=4)
-
-        del _backends
+        _update_backends(_config_file)
 
     # set values from config file to variable
     with open(_config_file) as f:
@@ -65,10 +70,31 @@ def _determine_backends():
     del _config_file
 
 
+def update_backends():
+    """
+    Updates all installed backends (and deletes old backend-configuration file)
+
+    Returns
+    -------
+
+    """
+    _config_file = __file__.replace("__init__.py", ".delira")
+    _BACKENDS = []
+
+    if os.path.isfile(_config_file):
+        os.remove(_config_file)
+
+    return get_backends()
+
+
 def get_backends():
     """
     Return List of currently available backends
 
+    Returns
+    -------
+    list
+        list of strings indicating all currently installed backends
     """
 
     if not __BACKENDS:

--- a/delira/__init__.py
+++ b/delira/__init__.py
@@ -6,13 +6,44 @@ import warnings
 warnings.simplefilter('default', DeprecationWarning)
 warnings.simplefilter('ignore', ImportWarning)
 
-# to register new pssible backends, they have to be added to this list.
+# to register new possible backends, they have to be added to this list.
 # each backend should consist of a tuple of length 2 with the first entry
 # being the package import name and the second being the backend abbreviation.
 # E.g. TensorFlow's package is named 'tensorflow' but if the package is found,
 # it will be considered as 'tf' later on
-__POSSIBLE_BACKENDS = [("torch", "torch"), ("tensorflow", "tf")]
+__POSSIBLE_BACKENDS = [("torch", "torch"), ("tensorflow", "tf"),
+                       ("sklearn", "sklearn")]
 __BACKENDS = []
+
+
+def _update_backends(config_file):
+    _backends = {}
+    # try to import all possible backends to determine valid backends
+
+    import importlib
+    for curr_backend in __POSSIBLE_BACKENDS:
+        try:
+            assert len(curr_backend) == 2
+            assert all([isinstance(_tmp, str) for _tmp in curr_backend]), \
+                "All entries in current backend must be strings"
+
+            # check if backend can be imported
+            bcknd = importlib.util.find_spec(curr_backend[0])
+
+            if bcknd is not None:
+                _backends[curr_backend[1]] = True
+            else:
+                _backends[curr_backend[1]] = False
+            del bcknd
+
+        except ValueError:
+            _backends[curr_backend[1]] = False
+
+    with open(config_file, "w") as f:
+        json.dump({"version": __version__, "backend": _backends},
+                  f, sort_keys=True, indent=4)
+
+    del _backends
 
 
 def _determine_backends():
@@ -22,33 +53,7 @@ def _determine_backends():
     # if file exists: load config into environment variables
 
     if not os.path.isfile(_config_file):
-        _backends = {}
-        # try to import all possible backends to determine valid backends
-
-        import importlib
-        for curr_backend in __POSSIBLE_BACKENDS:
-            try:
-                assert len(curr_backend) == 2
-                assert all([isinstance(_tmp, str) for _tmp in curr_backend]), \
-                    "All entries in current backend must be strings"
-
-                # check if backend can be imported
-                bcknd = importlib.util.find_spec(curr_backend[0])
-
-                if bcknd is not None:
-                    _backends[curr_backend[1]] = True
-                else:
-                    _backends[curr_backend[1]] = False
-                del bcknd
-
-            except ValueError:
-                _backends[curr_backend[1]] = False
-
-        with open(_config_file, "w") as f:
-            json.dump({"version": __version__, "backend": _backends},
-                      f, sort_keys=True, indent=4)
-
-        del _backends
+        _update_backends(_config_file)
 
     # set values from config file to variable
     with open(_config_file) as f:
@@ -61,6 +66,23 @@ def _determine_backends():
     del _config_file
 
 
+def update_backends():
+    """
+    Updates all installed backends (and deletes old backend-configuration file)
+
+    Returns
+    -------
+
+    """
+    _config_file = __file__.replace("__init__.py", ".delira")
+    _BACKENDS = []
+
+    if os.path.isfile(_config_file):
+        os.remove(_config_file)
+
+    return get_backends()
+
+
 def get_backends():
     """
     Return List of currently available backends
@@ -68,8 +90,7 @@ def get_backends():
     Returns
     -------
     list
-        list of strings containing the currently installed backends
-
+        list of strings indicating all currently installed backends
     """
 
     if not __BACKENDS:

--- a/delira/data_loading/sampler/__init__.py
+++ b/delira/data_loading/sampler/__init__.py
@@ -1,8 +1,8 @@
 from .abstract_sampler import AbstractSampler
 from .sequential_sampler import SequentialSampler, \
     PrevalenceSequentialSampler, StoppingPrevalenceSequentialSampler
-from .random_sampler import RandomSampler, PrevalenceRandomSampler, \
-    StoppingPrevalenceRandomSampler
+from .random_sampler import RandomSampler, RandomSamplerNoReplacement,\
+    PrevalenceRandomSampler, StoppingPrevalenceRandomSampler
 from .weighted_sampler import WeightedRandomSampler, \
     WeightedPrevalenceRandomSampler
 from .lambda_sampler import LambdaSampler
@@ -13,6 +13,7 @@ __all__ = [
     'PrevalenceSequentialSampler',
     'StoppingPrevalenceSequentialSampler',
     'RandomSampler',
+    'RandomSamplerNoReplacement',
     'PrevalenceRandomSampler',
     'StoppingPrevalenceRandomSampler',
     'WeightedRandomSampler',

--- a/delira/data_loading/sampler/__init__.py
+++ b/delira/data_loading/sampler/__init__.py
@@ -1,9 +1,10 @@
 from .abstract_sampler import AbstractSampler
 from .lambda_sampler import LambdaSampler
-from .random_sampler import RandomSampler, PrevalenceRandomSampler, \
-    StoppingPrevalenceRandomSampler
 from .sequential_sampler import SequentialSampler, \
     PrevalenceSequentialSampler, StoppingPrevalenceSequentialSampler
+
+from .random_sampler import RandomSampler, RandomSamplerNoReplacement,\
+    PrevalenceRandomSampler, StoppingPrevalenceRandomSampler
 from .weighted_sampler import WeightedRandomSampler, \
     WeightedPrevalenceRandomSampler
 
@@ -13,6 +14,7 @@ __all__ = [
     'PrevalenceSequentialSampler',
     'StoppingPrevalenceSequentialSampler',
     'RandomSampler',
+    'RandomSamplerNoReplacement',
     'PrevalenceRandomSampler',
     'StoppingPrevalenceRandomSampler',
     'WeightedRandomSampler',

--- a/delira/data_loading/sampler/__init__.py
+++ b/delira/data_loading/sampler/__init__.py
@@ -1,9 +1,9 @@
 from .abstract_sampler import AbstractSampler
 from .lambda_sampler import LambdaSampler
-from .random_sampler import RandomSampler, PrevalenceRandomSampler, \
-    StoppingPrevalenceRandomSampler
 from .sequential_sampler import SequentialSampler, \
     PrevalenceSequentialSampler, StoppingPrevalenceSequentialSampler
+from .random_sampler import RandomSampler, RandomSamplerNoReplacement,\
+    PrevalenceRandomSampler, StoppingPrevalenceRandomSampler
 from .weighted_sampler import WeightedRandomSampler, \
     WeightedPrevalenceRandomSampler
 
@@ -13,6 +13,7 @@ __all__ = [
     'PrevalenceSequentialSampler',
     'StoppingPrevalenceSequentialSampler',
     'RandomSampler',
+    'RandomSamplerNoReplacement',
     'PrevalenceRandomSampler',
     'StoppingPrevalenceRandomSampler',
     'WeightedRandomSampler',

--- a/delira/data_loading/sampler/random_sampler.py
+++ b/delira/data_loading/sampler/random_sampler.py
@@ -73,6 +73,7 @@ class RandomSamplerNoReplacement(RandomSampler):
     """
     Implements Random Sampling Without Replacement from whole Dataset
     """
+
     def __init__(self, indices):
         """
 

--- a/delira/data_loading/sampler/random_sampler.py
+++ b/delira/data_loading/sampler/random_sampler.py
@@ -9,7 +9,7 @@ from ..dataset import AbstractDataset
 
 class RandomSampler(AbstractSampler):
     """
-    Implements Random Sampling from whole Dataset
+    Implements Random Sampling With Replacement from whole Dataset
     """
 
     def __init__(self, indices):
@@ -26,6 +26,7 @@ class RandomSampler(AbstractSampler):
         super().__init__()
         self._indices = list(range(len(indices)))
         self._global_index = 0
+        self._replace = True
 
     def _get_indices(self, n_indices):
         """
@@ -58,14 +59,33 @@ class RandomSampler(AbstractSampler):
             new_global_idx = len(self._indices)
 
         indices = choice(self._indices,
-                         size=new_global_idx - self._global_index)
-        # indices = choices(
-        #   self._indices, k=new_global_idx - self._global_index)
+                         size=new_global_idx - self._global_index,
+                         replace=self._replace)
+
         self._global_index = new_global_idx
         return indices
 
     def __len__(self):
         return len(self._indices)
+
+
+class RandomSamplerNoReplacement(RandomSampler):
+    """
+    Implements Random Sampling Without Replacement from whole Dataset
+    """
+    def __init__(self, indices):
+        """
+
+        Parameters
+        ----------
+        indices : list
+            list of classes each sample belongs to. List index corresponds to
+            data index and the value at a certain index indicates the
+            corresponding class
+
+        """
+        super().__init__(indices)
+        self._replace = False
 
 
 class PrevalenceRandomSampler(AbstractSampler):

--- a/delira/data_loading/sampler/random_sampler.py
+++ b/delira/data_loading/sampler/random_sampler.py
@@ -8,7 +8,7 @@ from numpy import concatenate
 
 class RandomSampler(AbstractSampler):
     """
-    Implements Random Sampling from whole Dataset
+    Implements Random Sampling With Replacement from whole Dataset
     """
     def __init__(self, indices):
         """
@@ -24,6 +24,7 @@ class RandomSampler(AbstractSampler):
         super().__init__()
         self._indices = list(range(len(indices)))
         self._global_index = 0
+        self._replace = True
 
     def _get_indices(self, n_indices):
         """
@@ -56,13 +57,33 @@ class RandomSampler(AbstractSampler):
             new_global_idx = len(self._indices)
 
         indices = choice(self._indices,
-                         size=new_global_idx - self._global_index)
+                         size=new_global_idx - self._global_index,
+                         replace=self._replace)
         # indices = choices(self._indices, k=new_global_idx - self._global_index)
         self._global_index = new_global_idx
         return indices
 
     def __len__(self):
         return len(self._indices)
+
+
+class RandomSamplerNoReplacement(RandomSampler):
+    """
+    Implements Random Sampling Without Replacement from whole Dataset
+    """
+    def __init__(self, indices):
+        """
+
+        Parameters
+        ----------
+        indices : list
+            list of classes each sample belongs to. List index corresponds to
+            data index and the value at a certain index indicates the
+            corresponding class
+
+        """
+        super().__init__(indices)
+        self._replace = False
 
 
 class PrevalenceRandomSampler(AbstractSampler):

--- a/delira/io/__init__.py
+++ b/delira/io/__init__.py
@@ -7,3 +7,7 @@ if "TORCH" in get_backends():
 if "TF" in get_backends():
     from .tf import save_checkpoint as tf_save_checkpoint
     from .tf import load_checkpoint as tf_load_checkpoint
+
+if "SKLEARN" in get_backends():
+    from .sklearn import load_checkpoint as sklearn_load_checkpoint
+    from .sklearn import save_checkpoint as sklearn_save_checkpoint

--- a/delira/io/__init__.py
+++ b/delira/io/__init__.py
@@ -11,7 +11,3 @@ if "TORCH" in get_backends():
 if "TF" in get_backends():
     from .tf import save_checkpoint as tf_save_checkpoint
     from .tf import load_checkpoint as tf_load_checkpoint
-
-if "SKLEARN" in get_backends():
-    from .sklearn import load_checkpoint as sklearn_load_checkpoint
-    from .sklearn import save_checkpoint as sklearn_save_checkpoint

--- a/delira/io/__init__.py
+++ b/delira/io/__init__.py
@@ -17,5 +17,3 @@ if "TF" in get_backends():
 if "SKLEARN" in get_backends():
     from .sklearn import load_checkpoint as sklearn_load_checkpoint
     from .sklearn import save_checkpoint as sklearn_save_checkpoint
-
-

--- a/delira/io/__init__.py
+++ b/delira/io/__init__.py
@@ -7,7 +7,3 @@ if "TORCH" in get_backends():
 if "TF" in get_backends():
     from .tf import save_checkpoint as tf_save_checkpoint
     from .tf import load_checkpoint as tf_load_checkpoint
-
-if "SKLEARN" in get_backends():
-    from .sklearn import load_checkpoint as sklearn_load_checkpoint
-    from .sklearn import save_checkpoint as sklearn_save_checkpoint

--- a/delira/io/__init__.py
+++ b/delira/io/__init__.py
@@ -11,3 +11,7 @@ if "TORCH" in get_backends():
 if "TF" in get_backends():
     from .tf import save_checkpoint as tf_save_checkpoint
     from .tf import load_checkpoint as tf_load_checkpoint
+
+if "SKLEARN" in get_backends():
+    from .sklearn import load_checkpoint as sklearn_load_checkpoint
+    from .sklearn import save_checkpoint as sklearn_save_checkpoint

--- a/delira/io/sklearn.py
+++ b/delira/io/sklearn.py
@@ -1,0 +1,44 @@
+import logging
+import joblib
+logger = logging.getLogger(__name__)
+
+
+def save_checkpoint(file: str, model=None, epoch=None, **kwargs):
+    """
+    Save model's parameters
+
+    Parameters
+    ----------
+    file : str
+        filepath the model should be saved to
+    model : AbstractNetwork or None
+        the model which should be saved
+        if None: empty dict will be saved as state dict
+    epoch : int
+        current epoch (will also be pickled)
+
+    """
+
+    return joblib.dump({"model": model, "epoch": epoch}, file, **kwargs)
+
+
+def load_checkpoint(file, **kwargs):
+    """
+    Loads a saved model
+
+    Parameters
+    ----------
+    file : str
+        filepath to a file containing a saved model
+    **kwargs:
+        Additional keyword arguments (passed to torch.load)
+        Especially "map_location" is important to change the device the
+        state_dict should be loaded to
+
+    Returns
+    -------
+    OrderedDict
+        checkpoint state_dict
+
+    """
+    return joblib.load(file, **kwargs)

--- a/delira/models/__init__.py
+++ b/delira/models/__init__.py
@@ -14,3 +14,7 @@ if "TORCH" in get_backends():
 if "TF" in get_backends():
     from .abstract_network import AbstractTfNetwork
     from .classification import ClassificationNetworkBaseTf
+
+if "SKLEARN" in get_backends():
+    from .abstract_network import SklearnEstimator
+

--- a/delira/models/__init__.py
+++ b/delira/models/__init__.py
@@ -13,3 +13,6 @@ if "TORCH" in get_backends():
 if "TF" in get_backends():
     from .abstract_network import AbstractTfNetwork
     from .classification import ClassificationNetworkBaseTf
+
+if "SKLEARN" in get_backends():
+    from .abstract_network import SklearnEstimator

--- a/delira/models/__init__.py
+++ b/delira/models/__init__.py
@@ -17,4 +17,3 @@ if "TF" in get_backends():
 
 if "SKLEARN" in get_backends():
     from .abstract_network import SklearnEstimator
-

--- a/delira/models/__init__.py
+++ b/delira/models/__init__.py
@@ -14,3 +14,6 @@ if "TORCH" in get_backends():
 if "TF" in get_backends():
     from .abstract_network import AbstractTfNetwork
     from .classification import ClassificationNetworkBaseTf
+
+if "SKLEARN" in get_backends():
+    from .abstract_network import SklearnEstimator

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -155,13 +155,12 @@ if "SKLEARN" in get_backends():
                     "classes" in get_signature(self.partial_fit).parameters):
                 self.classes = None
 
-            if hasattr(self, "partial_fit"):
-                self.iterative_training = True
-            else:
-                self.iterative_training = False
-
         def __call__(self, *args, **kwargs):
             return {"pred": self.predict(*args, **kwargs)}
+
+        @property
+        def iterative_training(self):
+            return hasattr(self, "partial_fit")
 
         @staticmethod
         def prepare_batch(batch: dict, input_device, output_device):

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -142,7 +142,6 @@ if "SKLEARN" in get_backends():
     from inspect import signature as get_signature
 
     class SklearnEstimator(AbstractNetwork):
-<<<<<<< HEAD
         """
         Wrapper Class to wrap all ``sklearn`` estimators and provide delira
         compatibility
@@ -156,22 +155,17 @@ if "SKLEARN" in get_backends():
             module : :class:`sklearn.base.BaseEstimator`
                 the module to wrap
             """
-=======
-        def __init__(self, module: BaseEstimator):
->>>>>>> Add Wrapper for Sklearn estimators
+
             super().__init__()
 
             self.module = module
 
-<<<<<<< HEAD
             # forwards methods to self.module if necessary
-=======
->>>>>>> Add Wrapper for Sklearn estimators
+
             for key in ["fit", "partial_fit", "predict"]:
                 if hasattr(self.module, key):
                     setattr(self, key, getattr(self.module, key))
 
-<<<<<<< HEAD
             # if estimator is build dynamically based on input, classes have to
             # be passed at least at first time (we pass it every time), because
             # not every class is present in  every batch
@@ -238,22 +232,7 @@ if "SKLEARN" in get_backends():
                 device
 
             """
-=======
-            if (hasattr(self, "partial_fit") and
-                    "classes" in get_signature(self.partial_fit).parameters):
-                self.classes = None
 
-            if hasattr(self, "partial_fit"):
-                self.iterative_training = True
-            else:
-                self.iterative_training = False
-
-        def __call__(self, *args, **kwargs):
-            return {"pred": self.predict(*args, **kwargs)}
-
-        @staticmethod
-        def prepare_batch(batch: dict, input_device, output_device):
->>>>>>> Add Wrapper for Sklearn estimators
             new_batch = {"X": batch["data"]}
             if "label" in batch:
                 new_batch["y"] = batch["label"]

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -140,28 +140,94 @@ if "SKLEARN" in get_backends():
     from inspect import signature as get_signature
 
     class SklearnEstimator(AbstractNetwork):
+        """
+        Wrapper Class to wrap all ``sklearn`` estimators and provide delira
+        compatibility
+        """
+
         def __init__(self, module: BaseEstimator):
+            """
+
+            Parameters
+            ----------
+            module : :class:`sklearn.base.BaseEstimator`
+                the module to wrap
+            """
             super().__init__()
 
             self.module = module
 
+            # forwards methods to self.module if necessary
             for key in ["fit", "partial_fit", "predict"]:
                 if hasattr(self.module, key):
                     setattr(self, key, getattr(self.module, key))
 
-            if (hasattr(self, "partial_fit") and
+            # if estimator is build dynamically based on input, classes have to
+            # be passed at least at first time (we pass it every time), because
+            # not every class is present in  every batch
+            # variable is initialized here, but feeded during the training
+            if (self.iterative_training and
                     "classes" in get_signature(self.partial_fit).parameters):
                 self.classes = None
 
         def __call__(self, *args, **kwargs):
+            """
+            Calls ``self.predict`` with args and kwargs
+
+            Parameters
+            ----------
+            *args :
+                positional arguments of arbitrary number and type
+            **kwargs :
+                keyword arguments of arbitrary number and type
+
+            Returns
+            -------
+            dict
+                dictionary containing the predictions under key 'pred'
+
+            """
             return {"pred": self.predict(*args, **kwargs)}
 
         @property
         def iterative_training(self):
+            """
+            Property indicating, whether a the current module can be
+            trained iteratively (batchwise)
+
+            Returns
+            -------
+            bool
+                True: if current module can be trained iteratively
+                False: else
+
+            """
             return hasattr(self, "partial_fit")
 
         @staticmethod
         def prepare_batch(batch: dict, input_device, output_device):
+            """
+            Helper Function to prepare Network Inputs and Labels (convert them to
+            correct type and shape and push them to correct devices)
+
+            Parameters
+            ----------
+            batch : dict
+                dictionary containing all the data
+            input_device : Any
+                device for module inputs (will be ignored here; just given for
+                compatibility)
+            output_device : torch.device
+                device for module outputs (will be ignored here; just given for
+                compatibility)
+
+            Returns
+            -------
+            dict
+                dictionary containing data in correct type and shape and on correct
+                device
+
+            """
             new_batch = {"X": batch["data"]}
             if "label" in batch:
                 new_batch["y"] = batch["label"]
@@ -171,6 +237,40 @@ if "SKLEARN" in get_backends():
         @staticmethod
         def closure(model, data_dict: dict, optimizers: dict, losses={},
                     metrics={}, fold=0, **kwargs):
+            """
+            closure method to do a single training step
+
+
+            Parameters
+            ----------
+            model : :class:`SkLearnEstimator`
+                trainable model
+            data_dict : dict
+                dictionary containing the data
+            optimizers : dict
+                dictionary of optimizers to optimize model's parameters;
+                ignored here, just passed for compatibility reasons
+            losses : dict
+                dict holding the losses to calculate errors;
+                ignored here, just passed for compatibility reasons
+            metrics : dict
+                dict holding the metrics to calculate
+            fold : int
+                Current Fold in Crossvalidation (default: 0)
+            **kwargs:
+                additional keyword arguments
+
+            Returns
+            -------
+            dict
+                Metric values (with same keys as input dict metrics)
+            dict
+                Loss values (with same keys as input dict losses; will always
+                be empty here)
+            list
+                Arbitrary number of predictions as torch.Tensor
+
+            """
             if model.iterative_training:
                 fit_fn = model.partial_fit
 

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -582,7 +582,6 @@ if "TF" in get_backends():
             else:
                 return self._sess.run(self.outputs_eval, feed_dict=_feed_dict)
 
-
     class AbstractTfEagerNetwork(AbstractNetwork, tf.keras.layers.Layer):
         def __init__(self, data_format="channels_first", trainable=True,
                      name=None, dtype=None, **kwargs):
@@ -615,4 +614,3 @@ if "TF" in get_backends():
                     new_batch[k] = tf.convert_to_tensor(v.astype(np.float32))
 
             return new_batch
-

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -141,28 +141,94 @@ if "SKLEARN" in get_backends():
     from inspect import signature as get_signature
 
     class SklearnEstimator(AbstractNetwork):
+        """
+        Wrapper Class to wrap all ``sklearn`` estimators and provide delira
+        compatibility
+        """
+
         def __init__(self, module: BaseEstimator):
+            """
+
+            Parameters
+            ----------
+            module : :class:`sklearn.base.BaseEstimator`
+                the module to wrap
+            """
             super().__init__()
 
             self.module = module
 
+            # forwards methods to self.module if necessary
             for key in ["fit", "partial_fit", "predict"]:
                 if hasattr(self.module, key):
                     setattr(self, key, getattr(self.module, key))
 
-            if (hasattr(self, "partial_fit") and
+            # if estimator is build dynamically based on input, classes have to
+            # be passed at least at first time (we pass it every time), because
+            # not every class is present in  every batch
+            # variable is initialized here, but feeded during the training
+            if (self.iterative_training and
                     "classes" in get_signature(self.partial_fit).parameters):
                 self.classes = None
 
         def __call__(self, *args, **kwargs):
+            """
+            Calls ``self.predict`` with args and kwargs
+
+            Parameters
+            ----------
+            *args :
+                positional arguments of arbitrary number and type
+            **kwargs :
+                keyword arguments of arbitrary number and type
+
+            Returns
+            -------
+            dict
+                dictionary containing the predictions under key 'pred'
+
+            """
             return {"pred": self.predict(*args, **kwargs)}
 
         @property
         def iterative_training(self):
+            """
+            Property indicating, whether a the current module can be
+            trained iteratively (batchwise)
+
+            Returns
+            -------
+            bool
+                True: if current module can be trained iteratively
+                False: else
+
+            """
             return hasattr(self, "partial_fit")
 
         @staticmethod
         def prepare_batch(batch: dict, input_device, output_device):
+            """
+            Helper Function to prepare Network Inputs and Labels (convert them to
+            correct type and shape and push them to correct devices)
+
+            Parameters
+            ----------
+            batch : dict
+                dictionary containing all the data
+            input_device : Any
+                device for module inputs (will be ignored here; just given for
+                compatibility)
+            output_device : torch.device
+                device for module outputs (will be ignored here; just given for
+                compatibility)
+
+            Returns
+            -------
+            dict
+                dictionary containing data in correct type and shape and on correct
+                device
+
+            """
             new_batch = {"X": batch["data"]}
             if "label" in batch:
                 new_batch["y"] = batch["label"]
@@ -172,6 +238,40 @@ if "SKLEARN" in get_backends():
         @staticmethod
         def closure(model, data_dict: dict, optimizers: dict, losses={},
                     metrics={}, fold=0, **kwargs):
+            """
+            closure method to do a single training step
+
+
+            Parameters
+            ----------
+            model : :class:`SkLearnEstimator`
+                trainable model
+            data_dict : dict
+                dictionary containing the data
+            optimizers : dict
+                dictionary of optimizers to optimize model's parameters;
+                ignored here, just passed for compatibility reasons
+            losses : dict
+                dict holding the losses to calculate errors;
+                ignored here, just passed for compatibility reasons
+            metrics : dict
+                dict holding the metrics to calculate
+            fold : int
+                Current Fold in Crossvalidation (default: 0)
+            **kwargs:
+                additional keyword arguments
+
+            Returns
+            -------
+            dict
+                Metric values (with same keys as input dict metrics)
+            dict
+                Loss values (with same keys as input dict losses; will always
+                be empty here)
+            list
+                Arbitrary number of predictions as torch.Tensor
+
+            """
             if model.iterative_training:
                 fit_fn = model.partial_fit
 

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -142,6 +142,7 @@ if "SKLEARN" in get_backends():
     from inspect import signature as get_signature
 
     class SklearnEstimator(AbstractNetwork):
+<<<<<<< HEAD
         """
         Wrapper Class to wrap all ``sklearn`` estimators and provide delira
         compatibility
@@ -155,15 +156,22 @@ if "SKLEARN" in get_backends():
             module : :class:`sklearn.base.BaseEstimator`
                 the module to wrap
             """
+=======
+        def __init__(self, module: BaseEstimator):
+>>>>>>> Add Wrapper for Sklearn estimators
             super().__init__()
 
             self.module = module
 
+<<<<<<< HEAD
             # forwards methods to self.module if necessary
+=======
+>>>>>>> Add Wrapper for Sklearn estimators
             for key in ["fit", "partial_fit", "predict"]:
                 if hasattr(self.module, key):
                     setattr(self, key, getattr(self.module, key))
 
+<<<<<<< HEAD
             # if estimator is build dynamically based on input, classes have to
             # be passed at least at first time (we pass it every time), because
             # not every class is present in  every batch
@@ -230,6 +238,22 @@ if "SKLEARN" in get_backends():
                 device
 
             """
+=======
+            if (hasattr(self, "partial_fit") and
+                    "classes" in get_signature(self.partial_fit).parameters):
+                self.classes = None
+
+            if hasattr(self, "partial_fit"):
+                self.iterative_training = True
+            else:
+                self.iterative_training = False
+
+        def __call__(self, *args, **kwargs):
+            return {"pred": self.predict(*args, **kwargs)}
+
+        @staticmethod
+        def prepare_batch(batch: dict, input_device, output_device):
+>>>>>>> Add Wrapper for Sklearn estimators
             new_batch = {"X": batch["data"]}
             if "label" in batch:
                 new_batch["y"] = batch["label"]
@@ -273,6 +297,7 @@ if "SKLEARN" in get_backends():
                 Arbitrary number of predictions as torch.Tensor
 
             """
+
             if model.iterative_training:
                 fit_fn = model.partial_fit
 

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -142,28 +142,94 @@ if "SKLEARN" in get_backends():
     from inspect import signature as get_signature
 
     class SklearnEstimator(AbstractNetwork):
+        """
+        Wrapper Class to wrap all ``sklearn`` estimators and provide delira
+        compatibility
+        """
+
         def __init__(self, module: BaseEstimator):
+            """
+
+            Parameters
+            ----------
+            module : :class:`sklearn.base.BaseEstimator`
+                the module to wrap
+            """
             super().__init__()
 
             self.module = module
 
+            # forwards methods to self.module if necessary
             for key in ["fit", "partial_fit", "predict"]:
                 if hasattr(self.module, key):
                     setattr(self, key, getattr(self.module, key))
 
-            if (hasattr(self, "partial_fit") and
+            # if estimator is build dynamically based on input, classes have to
+            # be passed at least at first time (we pass it every time), because
+            # not every class is present in  every batch
+            # variable is initialized here, but feeded during the training
+            if (self.iterative_training and
                     "classes" in get_signature(self.partial_fit).parameters):
                 self.classes = None
 
         def __call__(self, *args, **kwargs):
+            """
+            Calls ``self.predict`` with args and kwargs
+
+            Parameters
+            ----------
+            *args :
+                positional arguments of arbitrary number and type
+            **kwargs :
+                keyword arguments of arbitrary number and type
+
+            Returns
+            -------
+            dict
+                dictionary containing the predictions under key 'pred'
+
+            """
             return {"pred": self.predict(*args, **kwargs)}
 
         @property
         def iterative_training(self):
+            """
+            Property indicating, whether a the current module can be
+            trained iteratively (batchwise)
+
+            Returns
+            -------
+            bool
+                True: if current module can be trained iteratively
+                False: else
+
+            """
             return hasattr(self, "partial_fit")
 
         @staticmethod
         def prepare_batch(batch: dict, input_device, output_device):
+            """
+            Helper Function to prepare Network Inputs and Labels (convert them to
+            correct type and shape and push them to correct devices)
+
+            Parameters
+            ----------
+            batch : dict
+                dictionary containing all the data
+            input_device : Any
+                device for module inputs (will be ignored here; just given for
+                compatibility)
+            output_device : torch.device
+                device for module outputs (will be ignored here; just given for
+                compatibility)
+
+            Returns
+            -------
+            dict
+                dictionary containing data in correct type and shape and on correct
+                device
+
+            """
             new_batch = {"X": batch["data"]}
             if "label" in batch:
                 new_batch["y"] = batch["label"]
@@ -173,6 +239,40 @@ if "SKLEARN" in get_backends():
         @staticmethod
         def closure(model, data_dict: dict, optimizers: dict, losses={},
                     metrics={}, fold=0, **kwargs):
+            """
+            closure method to do a single training step
+
+
+            Parameters
+            ----------
+            model : :class:`SkLearnEstimator`
+                trainable model
+            data_dict : dict
+                dictionary containing the data
+            optimizers : dict
+                dictionary of optimizers to optimize model's parameters;
+                ignored here, just passed for compatibility reasons
+            losses : dict
+                dict holding the losses to calculate errors;
+                ignored here, just passed for compatibility reasons
+            metrics : dict
+                dict holding the metrics to calculate
+            fold : int
+                Current Fold in Crossvalidation (default: 0)
+            **kwargs:
+                additional keyword arguments
+
+            Returns
+            -------
+            dict
+                Metric values (with same keys as input dict metrics)
+            dict
+                Loss values (with same keys as input dict losses; will always
+                be empty here)
+            list
+                Arbitrary number of predictions as torch.Tensor
+
+            """
             if model.iterative_training:
                 fit_fn = model.partial_fit
 

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -137,6 +137,67 @@ class AbstractNetwork(object):
         return self._init_kwargs
 
 
+if "SKLEARN" in get_backends():
+    from sklearn.base import BaseEstimator
+    from inspect import signature as get_signature
+
+    class SklearnEstimator(AbstractNetwork):
+        def __init__(self, module: BaseEstimator):
+            super().__init__()
+
+            self.module = module
+
+            for key in ["fit", "partial_fit", "predict"]:
+                if hasattr(self.module, key):
+                    setattr(self, key, getattr(self.module, key))
+
+            if (hasattr(self, "partial_fit") and
+                    "classes" in get_signature(self.partial_fit).parameters):
+                self.classes = None
+
+            if hasattr(self, "partial_fit"):
+                self.iterative_training = True
+            else:
+                self.iterative_training = False
+
+        def __call__(self, *args, **kwargs):
+            return {"pred": self.predict(*args, **kwargs)}
+
+        @staticmethod
+        def prepare_batch(batch: dict, input_device, output_device):
+            new_batch = {"X": batch["data"]}
+            if "label" in batch:
+                new_batch["y"] = batch["label"]
+
+            return new_batch
+
+        @staticmethod
+        def closure(model, data_dict: dict, optimizers: dict, losses={},
+                    metrics={}, fold=0, **kwargs):
+            if model.iterative_training:
+                fit_fn = model.partial_fit
+
+            else:
+                fit_fn = model.fit
+
+            if hasattr(model, "classes"):
+                # classes must be specified here, because not all classes
+                # must be present in each batch and some estimators are build
+                # dynamically
+                fit_fn(**data_dict, classes=model.classes)
+            else:
+                fit_fn(**data_dict)
+
+            preds = model(data_dict.pop("X"))
+
+            metric_vals = {}
+
+            for key, metric_fn in metrics.items():
+                metric_vals[key] = metric_fn(preds["pred"], **data_dict)
+
+            return metric_vals, {}, preds
+
+
 if "TORCH" in get_backends():
     import torch
 

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -153,13 +153,12 @@ if "SKLEARN" in get_backends():
                     "classes" in get_signature(self.partial_fit).parameters):
                 self.classes = None
 
-            if hasattr(self, "partial_fit"):
-                self.iterative_training = True
-            else:
-                self.iterative_training = False
-
         def __call__(self, *args, **kwargs):
             return {"pred": self.predict(*args, **kwargs)}
+
+        @property
+        def iterative_training(self):
+            return hasattr(self, "partial_fit")
 
         @staticmethod
         def prepare_batch(batch: dict, input_device, output_device):

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -136,6 +136,67 @@ class AbstractNetwork(object):
         return self._init_kwargs
 
 
+if "SKLEARN" in get_backends():
+    from sklearn.base import BaseEstimator
+    from inspect import signature as get_signature
+
+    class SklearnEstimator(AbstractNetwork):
+        def __init__(self, module: BaseEstimator):
+            super().__init__()
+
+            self.module = module
+
+            for key in ["fit", "partial_fit", "predict"]:
+                if hasattr(self.module, key):
+                    setattr(self, key, getattr(self.module, key))
+
+            if (hasattr(self, "partial_fit") and
+                    "classes" in get_signature(self.partial_fit).parameters):
+                self.classes = None
+
+            if hasattr(self, "partial_fit"):
+                self.iterative_training = True
+            else:
+                self.iterative_training = False
+
+        def __call__(self, *args, **kwargs):
+            return {"pred": self.predict(*args, **kwargs)}
+
+        @staticmethod
+        def prepare_batch(batch: dict, input_device, output_device):
+            new_batch = {"X": batch["data"]}
+            if "label" in batch:
+                new_batch["y"] = batch["label"]
+
+            return new_batch
+
+        @staticmethod
+        def closure(model, data_dict: dict, optimizers: dict, losses={},
+                    metrics={}, fold=0, **kwargs):
+            if model.iterative_training:
+                fit_fn = model.partial_fit
+
+            else:
+                fit_fn = model.fit
+
+            if hasattr(model, "classes"):
+                # classes must be specified here, because not all classes
+                # must be present in each batch and some estimators are build
+                # dynamically
+                fit_fn(**data_dict, classes=model.classes)
+            else:
+                fit_fn(**data_dict)
+
+            preds = model(data_dict.pop("X"))
+
+            metric_vals = {}
+
+            for key, metric_fn in metrics.items():
+                metric_vals[key] = metric_fn(preds["pred"], **data_dict)
+
+            return metric_vals, {}, preds
+
+
 if "TORCH" in get_backends():
     import torch
 

--- a/delira/models/abstract_network.py
+++ b/delira/models/abstract_network.py
@@ -154,13 +154,12 @@ if "SKLEARN" in get_backends():
                     "classes" in get_signature(self.partial_fit).parameters):
                 self.classes = None
 
-            if hasattr(self, "partial_fit"):
-                self.iterative_training = True
-            else:
-                self.iterative_training = False
-
         def __call__(self, *args, **kwargs):
             return {"pred": self.predict(*args, **kwargs)}
+
+        @property
+        def iterative_training(self):
+            return hasattr(self, "partial_fit")
 
         @staticmethod
         def prepare_batch(batch: dict, input_device, output_device):

--- a/delira/models/classification/classification_network.py
+++ b/delira/models/classification/classification_network.py
@@ -10,6 +10,9 @@ if "TORCH" in get_backends():
     from torchvision import models as t_models
     from delira.models.abstract_network import AbstractPyTorchNetwork
 
+    # use loss scaling if installed, otherwise falls back to "normal" backward
+    from ..model_utils import scale_loss
+
     class ClassificationNetworkBasePyTorch(AbstractPyTorchNetwork):
         """
         Implements basic classification with ResNet18
@@ -142,8 +145,9 @@ if "TORCH" in get_backends():
             if optimizers:
                 optimizers['default'].zero_grad()
                 # perform loss scaling via apex if half precision is enabled
-                with optimizers["default"].scale_loss(total_loss) \
-                        as scaled_loss:
+
+                with scale_loss(total_loss,
+                                optimizers["default"]) as scaled_loss:
                     scaled_loss.backward()
                 optimizers['default'].step()
 

--- a/delira/models/gan/generative_adversarial_network.py
+++ b/delira/models/gan/generative_adversarial_network.py
@@ -9,6 +9,8 @@ logger = logging.getLogger(__name__)
 if "TORCH" in get_backends():
     import torch
 
+    # use loss scaling if installed, otherwise falls back to "normal" backward
+    from ..model_utils import scale_loss
     from delira.models.abstract_network import AbstractPyTorchNetwork
 
     class GenerativeAdversarialNetworkBasePyTorch(AbstractPyTorchNetwork):
@@ -178,8 +180,8 @@ if "TORCH" in get_backends():
 
                     # perform loss scaling via apex if half precision is
                     # enabled
-                    with optimizers["discr"].scale_loss(
-                            total_loss_discr) as scaled_loss:
+                    with scale_loss(total_loss_discr,
+                                    optimizers["discr"]) as scaled_loss:
                         scaled_loss.backward(retain_graph=True)
                     optimizers["discr"].step()
 
@@ -216,10 +218,11 @@ if "TORCH" in get_backends():
                 if optimizers:
                     # actual backpropagation
                     optimizers["gen"].zero_grad()
+
                     # perform loss scaling via apex if half precision is
                     # enabled
-                    with optimizers["gen"].scale_loss(
-                            total_loss_gen) as scaled_loss:
+                    with scale_loss(total_loss_gen,
+                                    optimizers["gen"]) as scaled_loss:
                         scaled_loss.backward()
                     optimizers["gen"].step()
 

--- a/delira/models/model_utils.py
+++ b/delira/models/model_utils.py
@@ -1,0 +1,26 @@
+import contextlib
+
+try:
+    # use apex loss scaling if possible
+    # (and enabled, this is done internally by apex)
+    from apex import amp
+except ImportError:
+    # use no loss scaling with same API if apex is unavailable
+    amp = None
+
+
+@contextlib.contextmanager
+def scale_loss(loss,
+               optimizers,
+               loss_id=0,
+               model=None,
+               delay_unscale=False):
+    if amp is None:
+        yield loss
+
+    else:
+        with amp.scale_loss(loss=loss, optimizers=optimizers,
+                            loss_id=loss_id, model=model,
+                            delay_unscale=delay_unscale) as _loss:
+            yield _loss
+    return

--- a/delira/models/model_utils.py
+++ b/delira/models/model_utils.py
@@ -22,7 +22,7 @@ def scale_loss(loss,
     else:
         with amp.scale_loss(loss=loss, optimizers=optimizers,
                             loss_id=loss_id, model=model,
-                            delay_unscale=delay_unscale, 
+                            delay_unscale=delay_unscale,
                             **kwargs) as _loss:
             yield _loss
     return

--- a/delira/models/model_utils.py
+++ b/delira/models/model_utils.py
@@ -16,6 +16,46 @@ def scale_loss(loss,
                model=None,
                delay_unscale=False,
                **kwargs):
+    """
+    Context Manager which automatically switches between loss scaling via
+    apex.amp (if apex is available) and no loss scaling
+
+    Parameters
+    ----------
+    loss : :class:`torch.Tensor`
+        a pytorch tensor containing the loss value
+    optimizers : list
+        a list of :class:`torch.optim.Optimizer` containing all optimizers,
+        which are holding paraneters affected by the backpropagation of the
+        current loss value
+    loss_id : int
+        When used in conjunction with the ``num_losses`` argument
+        to ``amp.initialize``, enables Amp to use a different loss scale per
+        loss.  ``loss_id`` must be an integer between 0 and ``num_losses`` that
+        tells Amp which loss is being used for the current backward pass.
+        If ``loss_id`` is left unspecified, Amp will use the default global
+        loss scaler for this backward pass.
+    model : :class:`AbstractPyTorchNetwork` or None
+        Currently unused, reserved to enable future optimizations.
+    delay_unscale : bool
+        ``delay_unscale`` is never necessary, and the default value of
+        ``False`` is strongly recommended. If ``True``, Amp will not unscale
+        the gradients or perform model->master gradient copies on
+        context manager exit. ``delay_unscale=True`` is a minor ninja
+        performance optimization and can result
+        in weird gotchas (especially with multiple models/optimizers/losses),
+        so only use it if you know what you're doing.
+    **kwargs :
+        additional keyword arguments; currently unused, but provided for the
+        case amp decides to extend the functionality here
+
+    Yields
+    ------
+    :class:`torch.Tensor`
+        the new loss value (scaled if apex.amp is available and was configured
+        to do so, unscaled in all other cases)
+
+    """
 
     if amp is None:
         yield loss

--- a/delira/models/model_utils.py
+++ b/delira/models/model_utils.py
@@ -14,13 +14,15 @@ def scale_loss(loss,
                optimizers,
                loss_id=0,
                model=None,
-               delay_unscale=False):
+               delay_unscale=False,
+               **kwargs):
     if amp is None:
         yield loss
 
     else:
         with amp.scale_loss(loss=loss, optimizers=optimizers,
                             loss_id=loss_id, model=model,
-                            delay_unscale=delay_unscale) as _loss:
+                            delay_unscale=delay_unscale, 
+                            **kwargs) as _loss:
             yield _loss
     return

--- a/delira/models/segmentation/unet.py
+++ b/delira/models/segmentation/unet.py
@@ -9,6 +9,8 @@ if "TORCH" in get_backends():
     from torch.nn import init
     import logging
     from ..abstract_network import AbstractPyTorchNetwork
+    # use loss scaling if installed, otherwise falls back to "normal" backward
+    from ..model_utils import scale_loss
 
     class UNet2dPyTorch(AbstractPyTorchNetwork):
         """
@@ -250,8 +252,9 @@ if "TORCH" in get_backends():
             if optimizers:
                 optimizers['default'].zero_grad()
                 # perform loss scaling via apex if half precision is enabled
-                with optimizers["default"].scale_loss(total_loss) \
-                        as scaled_loss:
+                with scale_loss(total_loss,
+                                optimizers["default"]) as scaled_loss:
+
                     scaled_loss.backward()
                 optimizers['default'].step()
 
@@ -694,8 +697,9 @@ if "TORCH" in get_backends():
             if optimizers:
                 optimizers['default'].zero_grad()
                 # perform loss scaling via apex if half precision is enabled
-                with optimizers["default"].scale_loss(total_loss) \
-                        as scaled_loss:
+
+                with scale_loss(total_loss,
+                                optimizers["default"]) as scaled_loss:
                     scaled_loss.backward()
                 optimizers['default'].step()
 

--- a/delira/models/segmentation/unet.py
+++ b/delira/models/segmentation/unet.py
@@ -252,9 +252,9 @@ if "TORCH" in get_backends():
             if optimizers:
                 optimizers['default'].zero_grad()
                 # perform loss scaling via apex if half precision is enabled
-
                 with scale_loss(total_loss,
                                 optimizers["default"]) as scaled_loss:
+
                     scaled_loss.backward()
                 optimizers['default'].step()
 
@@ -700,7 +700,6 @@ if "TORCH" in get_backends():
 
                 with scale_loss(total_loss,
                                 optimizers["default"]) as scaled_loss:
-
                     scaled_loss.backward()
                 optimizers['default'].step()
 

--- a/delira/training/__init__.py
+++ b/delira/training/__init__.py
@@ -12,3 +12,7 @@ if "TORCH" in get_backends():
 if "TF" in get_backends():
     from .experiment import TfExperiment
     from .tf_trainer import TfNetworkTrainer
+
+if "SKLEARN" in get_backends():
+    from .sklearn_trainer import SklearnEstimatorTrainer
+    from .experiment import SkLearnExperiment

--- a/delira/training/__init__.py
+++ b/delira/training/__init__.py
@@ -13,3 +13,7 @@ if "TORCH" in get_backends():
 if "TF" in get_backends():
     from .experiment import TfExperiment
     from .tf_trainer import TfNetworkTrainer
+
+if "SKLEARN" in get_backends():
+    from .sklearn_trainer import SklearnEstimatorTrainer
+    from .experiment import SkLearnExperiment

--- a/delira/training/__init__.py
+++ b/delira/training/__init__.py
@@ -14,3 +14,7 @@ if "TORCH" in get_backends():
 if "TF" in get_backends():
     from .experiment import TfExperiment
     from .tf_trainer import TfNetworkTrainer
+
+if "SKLEARN" in get_backends():
+    from .sklearn_trainer import SklearnEstimatorTrainer
+    from .experiment import SkLearnExperiment

--- a/delira/training/__init__.py
+++ b/delira/training/__init__.py
@@ -18,4 +18,3 @@ if "TF" in get_backends():
 if "SKLEARN" in get_backends():
     from .sklearn_trainer import SklearnEstimatorTrainer
     from .experiment import SkLearnExperiment
-

--- a/delira/training/base_trainer.py
+++ b/delira/training/base_trainer.py
@@ -774,7 +774,7 @@ class BaseNetworkTrainer(Predictor):
                 for x in files])
 
             latest_state_path = [x for x in files
-                                 if x.startswith("checkpoint_%d"
+                                 if x.startswith("checkpoint_epoch_%d"
                                                  % latest_epoch)][0]
 
             return latest_state_path, latest_epoch

--- a/delira/training/experiment.py
+++ b/delira/training/experiment.py
@@ -1247,3 +1247,155 @@ if "TF" in get_backends():
                                 metrics=metrics, metric_keys=metric_keys,
                                 verbose=verbose, prepare_batch=prepare_batch,
                                 convert_fn=convert_fn, **kwargs)
+
+if "SKLEARN" in get_backends():
+    from sklearn.base import BaseEstimator
+    from ..models import SklearnEstimator
+    from .sklearn_trainer import SklearnEstimatorTrainer
+
+    class SkLearnExperiment(BaseExperiment):
+        def __init__(self,
+                     params: typing.Union[str, Parameters],
+                     model_cls: BaseEstimator,
+                     n_epochs=None,
+                     name=None,
+                     save_path=None,
+                     key_mapping=None,
+                     val_score_key=None,
+                     checkpoint_freq=1,
+                     trainer_cls=SklearnEstimatorTrainer,
+                     model_wrapper_cls=SklearnEstimator,
+                     **kwargs):
+            """
+
+            Parameters
+            ----------
+            params : :class:`Parameters` or str
+                the training parameters, if string is passed,
+                it is treated as a path to a pickle file, where the
+                parameters are loaded from
+            model_cls : Subclass of :class:`sklearn.base.BaseEstimator`
+                the class implementing the model to train (will be wrapped by
+                :class:`SkLearnEstimator`)
+            n_epochs : int or None
+                the number of epochs to train, if None: can be specified later
+                during actual training
+            name : str or None
+                the Experiment's name
+            save_path : str or None
+                the path to save the results and checkpoints to.
+                if None: Current working directory will be used
+            key_mapping : dict
+                mapping between data_dict and model inputs (necessary for
+                prediction with :class:`Predictor`-API), if no keymapping is
+                given, a default key_mapping of {"x": "data"} will be used here
+            val_score_key : str or None
+                key defining which metric to use for validation (determining
+                best model and scheduling lr); if None: No validation-based
+                operations will be done (model might still get validated,
+                but validation metrics can only be logged and not used further)
+            checkpoint_freq : int
+                frequency of saving checkpoints (1 denotes saving every epoch,
+                2 denotes saving every second epoch etc.); default: 1
+            trainer_cls : subclass of :class:`SkLearnEstimatorTrainer`
+                the trainer class to use for training the model, defaults to
+                :class:`PyTorchNetworkTrainer`
+            model_wrapper_cls : subclass of :class:`SkLearnEstimator`
+                class wrapping the actual sklearn model to provide delira
+                compatibility
+            **kwargs :
+                additional keyword arguments
+
+            """
+
+            if key_mapping is None:
+                key_mapping = {"X": "X"}
+
+            super().__init__(params=params,
+                             model_cls=model_cls,
+                             n_epochs=n_epochs,
+                             name=name,
+                             save_path=save_path,
+                             key_mapping=key_mapping,
+                             val_score_key=val_score_key,
+                             checkpoint_freq=checkpoint_freq,
+                             trainer_cls=trainer_cls,
+                             **kwargs)
+
+            self._model_wrapper_cls = model_wrapper_cls
+
+        def _setup_training(self, params, **kwargs):
+            """
+                Handles the setup for training case
+
+                Parameters
+                ----------
+                params : :class:`Parameters`
+                    the parameters containing the model and training kwargs
+                **kwargs :
+                    additional keyword arguments
+
+                Returns
+                -------
+                :class:`BaseNetworkTrainer`
+                    the created trainer
+            """
+            model_params = params.permute_training_on_top().model
+
+            model_kwargs = {**model_params.fixed, **model_params.variable}
+
+            _model = self.model_cls(**model_kwargs)
+            model = self._model_wrapper_cls(_model)
+
+            training_params = params.permute_training_on_top().training
+            train_metrics = training_params.nested_get("train_metrics", {})
+            val_metrics = training_params.nested_get("val_metrics", {})
+
+            # necessary for resuming training from a given path
+            save_path = kwargs.pop("save_path", os.path.join(
+                self.save_path,
+                "checkpoints",
+                "run_%02d" % self._run))
+
+            return self.trainer_cls(
+                estimator=model,
+                save_path=save_path,
+                key_mapping=self.key_mapping,
+                train_metrics=train_metrics,
+                val_metrics=val_metrics,
+                save_freq=self.checkpoint_freq,
+                **kwargs
+            )
+
+        def _setup_test(self, params, model, convert_batch_to_npy_fn,
+                        prepare_batch_fn, **kwargs):
+            """
+
+            Parameters
+            ----------
+            params : :class:`Parameters`
+                the parameters containing the model and training kwargs
+                (ignored here, just passed for subclassing and unified API)
+            model : :class:`AbstractNetwork`
+                the model to test
+            convert_batch_to_npy_fn : function
+                function to convert a batch of tensors to numpy
+            prepare_batch_fn : function
+                function to convert a batch-dict to a format accepted by the model.
+                This conversion typically includes dtype-conversion, reshaping,
+                wrapping to backend-specific tensors and pushing to correct devices
+            **kwargs :
+                additional keyword arguments
+
+            Returns
+            -------
+            :class:`Predictor`
+                the created predictor
+
+            """
+            if isinstance(model, BaseEstimator):
+                model = SklearnEstimator(model)
+
+            return super()._setup_test(params, model, convert_batch_to_npy_fn,
+                                       prepare_batch_fn, **kwargs)
+

--- a/delira/training/experiment.py
+++ b/delira/training/experiment.py
@@ -1369,15 +1369,19 @@ if "TF" in get_backends():
             if key_mapping is None:
                 key_mapping = {"x": "data"}
 
-                BaseExperiment.__init__(self, params=params, model_cls=model_cls,
-                                        n_epochs=n_epochs, name=name,
-                                        save_path=save_path,
-                                        key_mapping=key_mapping,
-                                        val_score_key=val_score_key,
-                                        optim_builder=optim_builder,
-                                        checkpoint_freq=checkpoint_freq,
-                                        trainer_cls=trainer_cls,
-                                        **kwargs)
+                BaseExperiment.__init__(
+                    self,
+                    params=params,
+                    model_cls=model_cls,
+                    n_epochs=n_epochs,
+                    name=name,
+                    save_path=save_path,
+                    key_mapping=key_mapping,
+                    val_score_key=val_score_key,
+                    optim_builder=optim_builder,
+                    checkpoint_freq=checkpoint_freq,
+                    trainer_cls=trainer_cls,
+                    **kwargs)
 
         def setup(self, params, training=True, **kwargs):
             """

--- a/delira/training/experiment.py
+++ b/delira/training/experiment.py
@@ -1403,4 +1403,3 @@ if "SKLEARN" in get_backends():
 
             return super()._setup_test(params, model, convert_batch_to_npy_fn,
                                        prepare_batch_fn, **kwargs)
-

--- a/delira/training/experiment.py
+++ b/delira/training/experiment.py
@@ -1310,3 +1310,155 @@ if "TF" in get_backends():
                                 metrics=metrics, metric_keys=metric_keys,
                                 verbose=verbose, prepare_batch=prepare_batch,
                                 convert_fn=convert_fn, **kwargs)
+
+if "SKLEARN" in get_backends():
+    from sklearn.base import BaseEstimator
+    from ..models import SklearnEstimator
+    from .sklearn_trainer import SklearnEstimatorTrainer
+
+    class SkLearnExperiment(BaseExperiment):
+        def __init__(self,
+                     params: typing.Union[str, Parameters],
+                     model_cls: BaseEstimator,
+                     n_epochs=None,
+                     name=None,
+                     save_path=None,
+                     key_mapping=None,
+                     val_score_key=None,
+                     checkpoint_freq=1,
+                     trainer_cls=SklearnEstimatorTrainer,
+                     model_wrapper_cls=SklearnEstimator,
+                     **kwargs):
+            """
+
+            Parameters
+            ----------
+            params : :class:`Parameters` or str
+                the training parameters, if string is passed,
+                it is treated as a path to a pickle file, where the
+                parameters are loaded from
+            model_cls : Subclass of :class:`sklearn.base.BaseEstimator`
+                the class implementing the model to train (will be wrapped by
+                :class:`SkLearnEstimator`)
+            n_epochs : int or None
+                the number of epochs to train, if None: can be specified later
+                during actual training
+            name : str or None
+                the Experiment's name
+            save_path : str or None
+                the path to save the results and checkpoints to.
+                if None: Current working directory will be used
+            key_mapping : dict
+                mapping between data_dict and model inputs (necessary for
+                prediction with :class:`Predictor`-API), if no keymapping is
+                given, a default key_mapping of {"x": "data"} will be used here
+            val_score_key : str or None
+                key defining which metric to use for validation (determining
+                best model and scheduling lr); if None: No validation-based
+                operations will be done (model might still get validated,
+                but validation metrics can only be logged and not used further)
+            checkpoint_freq : int
+                frequency of saving checkpoints (1 denotes saving every epoch,
+                2 denotes saving every second epoch etc.); default: 1
+            trainer_cls : subclass of :class:`SkLearnEstimatorTrainer`
+                the trainer class to use for training the model, defaults to
+                :class:`PyTorchNetworkTrainer`
+            model_wrapper_cls : subclass of :class:`SkLearnEstimator`
+                class wrapping the actual sklearn model to provide delira
+                compatibility
+            **kwargs :
+                additional keyword arguments
+
+            """
+
+            if key_mapping is None:
+                key_mapping = {"X": "X"}
+
+            super().__init__(params=params,
+                             model_cls=model_cls,
+                             n_epochs=n_epochs,
+                             name=name,
+                             save_path=save_path,
+                             key_mapping=key_mapping,
+                             val_score_key=val_score_key,
+                             checkpoint_freq=checkpoint_freq,
+                             trainer_cls=trainer_cls,
+                             **kwargs)
+
+            self._model_wrapper_cls = model_wrapper_cls
+
+        def _setup_training(self, params, **kwargs):
+            """
+                Handles the setup for training case
+
+                Parameters
+                ----------
+                params : :class:`Parameters`
+                    the parameters containing the model and training kwargs
+                **kwargs :
+                    additional keyword arguments
+
+                Returns
+                -------
+                :class:`BaseNetworkTrainer`
+                    the created trainer
+            """
+            model_params = params.permute_training_on_top().model
+
+            model_kwargs = {**model_params.fixed, **model_params.variable}
+
+            _model = self.model_cls(**model_kwargs)
+            model = self._model_wrapper_cls(_model)
+
+            training_params = params.permute_training_on_top().training
+            train_metrics = training_params.nested_get("train_metrics", {})
+            val_metrics = training_params.nested_get("val_metrics", {})
+
+            # necessary for resuming training from a given path
+            save_path = kwargs.pop("save_path", os.path.join(
+                self.save_path,
+                "checkpoints",
+                "run_%02d" % self._run))
+
+            return self.trainer_cls(
+                estimator=model,
+                save_path=save_path,
+                key_mapping=self.key_mapping,
+                train_metrics=train_metrics,
+                val_metrics=val_metrics,
+                save_freq=self.checkpoint_freq,
+                **kwargs
+            )
+
+        def _setup_test(self, params, model, convert_batch_to_npy_fn,
+                        prepare_batch_fn, **kwargs):
+            """
+
+            Parameters
+            ----------
+            params : :class:`Parameters`
+                the parameters containing the model and training kwargs
+                (ignored here, just passed for subclassing and unified API)
+            model : :class:`AbstractNetwork`
+                the model to test
+            convert_batch_to_npy_fn : function
+                function to convert a batch of tensors to numpy
+            prepare_batch_fn : function
+                function to convert a batch-dict to a format accepted by the model.
+                This conversion typically includes dtype-conversion, reshaping,
+                wrapping to backend-specific tensors and pushing to correct devices
+            **kwargs :
+                additional keyword arguments
+
+            Returns
+            -------
+            :class:`Predictor`
+                the created predictor
+
+            """
+            if isinstance(model, BaseEstimator):
+                model = SklearnEstimator(model)
+
+            return super()._setup_test(params, model, convert_batch_to_npy_fn,
+                                       prepare_batch_fn, **kwargs)
+

--- a/delira/training/experiment.py
+++ b/delira/training/experiment.py
@@ -1222,3 +1222,155 @@ if "TF" in get_backends():
                                 metrics=metrics, metric_keys=metric_keys,
                                 verbose=verbose, prepare_batch=prepare_batch,
                                 convert_fn=convert_fn, **kwargs)
+
+if "SKLEARN" in get_backends():
+    from sklearn.base import BaseEstimator
+    from ..models import SklearnEstimator
+    from .sklearn_trainer import SklearnEstimatorTrainer
+
+    class SkLearnExperiment(BaseExperiment):
+        def __init__(self,
+                     params: typing.Union[str, Parameters],
+                     model_cls: BaseEstimator,
+                     n_epochs=None,
+                     name=None,
+                     save_path=None,
+                     key_mapping=None,
+                     val_score_key=None,
+                     checkpoint_freq=1,
+                     trainer_cls=SklearnEstimatorTrainer,
+                     model_wrapper_cls=SklearnEstimator,
+                     **kwargs):
+            """
+
+            Parameters
+            ----------
+            params : :class:`Parameters` or str
+                the training parameters, if string is passed,
+                it is treated as a path to a pickle file, where the
+                parameters are loaded from
+            model_cls : Subclass of :class:`sklearn.base.BaseEstimator`
+                the class implementing the model to train (will be wrapped by
+                :class:`SkLearnEstimator`)
+            n_epochs : int or None
+                the number of epochs to train, if None: can be specified later
+                during actual training
+            name : str or None
+                the Experiment's name
+            save_path : str or None
+                the path to save the results and checkpoints to.
+                if None: Current working directory will be used
+            key_mapping : dict
+                mapping between data_dict and model inputs (necessary for
+                prediction with :class:`Predictor`-API), if no keymapping is
+                given, a default key_mapping of {"x": "data"} will be used here
+            val_score_key : str or None
+                key defining which metric to use for validation (determining
+                best model and scheduling lr); if None: No validation-based
+                operations will be done (model might still get validated,
+                but validation metrics can only be logged and not used further)
+            checkpoint_freq : int
+                frequency of saving checkpoints (1 denotes saving every epoch,
+                2 denotes saving every second epoch etc.); default: 1
+            trainer_cls : subclass of :class:`SkLearnEstimatorTrainer`
+                the trainer class to use for training the model, defaults to
+                :class:`PyTorchNetworkTrainer`
+            model_wrapper_cls : subclass of :class:`SkLearnEstimator`
+                class wrapping the actual sklearn model to provide delira
+                compatibility
+            **kwargs :
+                additional keyword arguments
+
+            """
+
+            if key_mapping is None:
+                key_mapping = {"X": "X"}
+
+            super().__init__(params=params,
+                             model_cls=model_cls,
+                             n_epochs=n_epochs,
+                             name=name,
+                             save_path=save_path,
+                             key_mapping=key_mapping,
+                             val_score_key=val_score_key,
+                             checkpoint_freq=checkpoint_freq,
+                             trainer_cls=trainer_cls,
+                             **kwargs)
+
+            self._model_wrapper_cls = model_wrapper_cls
+
+        def _setup_training(self, params, **kwargs):
+            """
+                Handles the setup for training case
+
+                Parameters
+                ----------
+                params : :class:`Parameters`
+                    the parameters containing the model and training kwargs
+                **kwargs :
+                    additional keyword arguments
+
+                Returns
+                -------
+                :class:`BaseNetworkTrainer`
+                    the created trainer
+            """
+            model_params = params.permute_training_on_top().model
+
+            model_kwargs = {**model_params.fixed, **model_params.variable}
+
+            _model = self.model_cls(**model_kwargs)
+            model = self._model_wrapper_cls(_model)
+
+            training_params = params.permute_training_on_top().training
+            train_metrics = training_params.nested_get("train_metrics", {})
+            val_metrics = training_params.nested_get("val_metrics", {})
+
+            # necessary for resuming training from a given path
+            save_path = kwargs.pop("save_path", os.path.join(
+                self.save_path,
+                "checkpoints",
+                "run_%02d" % self._run))
+
+            return self.trainer_cls(
+                estimator=model,
+                save_path=save_path,
+                key_mapping=self.key_mapping,
+                train_metrics=train_metrics,
+                val_metrics=val_metrics,
+                save_freq=self.checkpoint_freq,
+                **kwargs
+            )
+
+        def _setup_test(self, params, model, convert_batch_to_npy_fn,
+                        prepare_batch_fn, **kwargs):
+            """
+
+            Parameters
+            ----------
+            params : :class:`Parameters`
+                the parameters containing the model and training kwargs
+                (ignored here, just passed for subclassing and unified API)
+            model : :class:`AbstractNetwork`
+                the model to test
+            convert_batch_to_npy_fn : function
+                function to convert a batch of tensors to numpy
+            prepare_batch_fn : function
+                function to convert a batch-dict to a format accepted by the model.
+                This conversion typically includes dtype-conversion, reshaping,
+                wrapping to backend-specific tensors and pushing to correct devices
+            **kwargs :
+                additional keyword arguments
+
+            Returns
+            -------
+            :class:`Predictor`
+                the created predictor
+
+            """
+            if isinstance(model, BaseEstimator):
+                model = SklearnEstimator(model)
+
+            return super()._setup_test(params, model, convert_batch_to_npy_fn,
+                                       prepare_batch_fn, **kwargs)
+

--- a/delira/training/experiment.py
+++ b/delira/training/experiment.py
@@ -343,7 +343,7 @@ class BaseExperiment(TrixiExperiment):
     def test(self, network, test_data: BaseDataManager,
              metrics: dict, metric_keys=None,
              verbose=False, prepare_batch=lambda x: x,
-             convert_fn=lambda x: x, **kwargs):
+             convert_fn=lambda *x, **y: (x, y), **kwargs):
         """
         Setup and run testing on a given network
 
@@ -1351,7 +1351,7 @@ if "SKLEARN" in get_backends():
             params : :class:`Parameters`
                 the parameters containing the model and training kwargs
                 (ignored here, just passed for subclassing and unified API)
-            model : :class:`AbstractNetwork`
+            model : :class:`sklearn.base.BaseEstimator`
                 the model to test
             convert_batch_to_npy_fn : function
                 function to convert a batch of tensors to numpy
@@ -1368,8 +1368,13 @@ if "SKLEARN" in get_backends():
                 the created predictor
 
             """
-            if isinstance(model, BaseEstimator):
+            if not isinstance(model, SklearnEstimator):
                 model = SklearnEstimator(model)
+
+            if prepare_batch_fn is None:
+                prepare_batch_fn = partial(model.prepare_batch,
+                                           input_device="cpu",
+                                           output_device="cpu")
 
             return super()._setup_test(params, model, convert_batch_to_npy_fn,
                                        prepare_batch_fn, **kwargs)

--- a/delira/training/experiment.py
+++ b/delira/training/experiment.py
@@ -349,7 +349,7 @@ class BaseExperiment(object):
     def test(self, network, test_data: BaseDataManager,
              metrics: dict, metric_keys=None,
              verbose=False, prepare_batch=lambda x: x,
-             convert_fn=lambda x: x, **kwargs):
+             convert_fn=lambda *x, **y: (x, y), **kwargs):
         """
         Setup and run testing on a given network
 
@@ -1376,7 +1376,7 @@ if "SKLEARN" in get_backends():
             params : :class:`Parameters`
                 the parameters containing the model and training kwargs
                 (ignored here, just passed for subclassing and unified API)
-            model : :class:`AbstractNetwork`
+            model : :class:`sklearn.base.BaseEstimator`
                 the model to test
             convert_batch_to_npy_fn : function
                 function to convert a batch of tensors to numpy
@@ -1393,8 +1393,13 @@ if "SKLEARN" in get_backends():
                 the created predictor
 
             """
-            if isinstance(model, BaseEstimator):
+            if not isinstance(model, SklearnEstimator):
                 model = SklearnEstimator(model)
+
+            if prepare_batch_fn is None:
+                prepare_batch_fn = partial(model.prepare_batch,
+                                           input_device="cpu",
+                                           output_device="cpu")
 
             return super()._setup_test(params, model, convert_batch_to_npy_fn,
                                        prepare_batch_fn, **kwargs)

--- a/delira/training/experiment.py
+++ b/delira/training/experiment.py
@@ -349,7 +349,7 @@ class BaseExperiment(object):
     def test(self, network, test_data: BaseDataManager,
              metrics: dict, metric_keys=None,
              verbose=False, prepare_batch=lambda x: x,
-             convert_fn=lambda x: x, **kwargs):
+             convert_fn=lambda *x, **y: (x, y), **kwargs):
         """
         Setup and run testing on a given network
 
@@ -1439,7 +1439,7 @@ if "SKLEARN" in get_backends():
             params : :class:`Parameters`
                 the parameters containing the model and training kwargs
                 (ignored here, just passed for subclassing and unified API)
-            model : :class:`AbstractNetwork`
+            model : :class:`sklearn.base.BaseEstimator`
                 the model to test
             convert_batch_to_npy_fn : function
                 function to convert a batch of tensors to numpy
@@ -1456,8 +1456,13 @@ if "SKLEARN" in get_backends():
                 the created predictor
 
             """
-            if isinstance(model, BaseEstimator):
+            if not isinstance(model, SklearnEstimator):
                 model = SklearnEstimator(model)
+
+            if prepare_batch_fn is None:
+                prepare_batch_fn = partial(model.prepare_batch,
+                                           input_device="cpu",
+                                           output_device="cpu")
 
             return super()._setup_test(params, model, convert_batch_to_npy_fn,
                                        prepare_batch_fn, **kwargs)

--- a/delira/training/predictor.py
+++ b/delira/training/predictor.py
@@ -26,7 +26,7 @@ class Predictor(object):
     def __init__(
             self, model, key_mapping: dict,
             convert_batch_to_npy_fn=convert_batch_to_numpy_identity,
-            prepare_batch_fn=lambda x: x, **kwargs):
+            prepare_batch_fn=lambda **x: x, **kwargs):
         """
 
         Parameters

--- a/delira/training/predictor.py
+++ b/delira/training/predictor.py
@@ -25,7 +25,7 @@ class Predictor(object):
     def __init__(
             self, model, key_mapping: dict,
             convert_batch_to_npy_fn=convert_batch_to_numpy_identity,
-            prepare_batch_fn=lambda x: x, **kwargs):
+            prepare_batch_fn=lambda **x: x, **kwargs):
         """
 
         Parameters

--- a/delira/training/predictor.py
+++ b/delira/training/predictor.py
@@ -73,7 +73,7 @@ class Predictor(object):
         convert_batch_to_npy_fn : type
             a callable function to convert tensors in positional and keyword
             arguments to numpy
-        prepare_batch_fn : type
+        prepare_batch_fn : (dict, str, str) -> dict
             function converting a batch-tensor to the framework specific
             tensor-type and pushing it to correct device, default: identity
             function

--- a/delira/training/pytorch_trainer.py
+++ b/delira/training/pytorch_trainer.py
@@ -57,9 +57,14 @@ if "TORCH" in get_backends():
                      metric_keys=None,
                      convert_batch_to_npy_fn=convert_torch_tensor_to_npy,
                      mixed_precision=False,
-                     mixed_precision_kwargs={"enable_caching": True,
-                                             "verbose": False,
-                                             "allow_banned": False},
+                     mixed_precision_kwargs={"opt_level": "o0",
+                                             "cast_model_type": None,
+                                             "patch_torch_functions": None,
+                                             "master_weights": None,
+                                             "loss_scale": None,
+                                             "cast_model_outputs": None,
+                                             "num_losses": 1,
+                                             "verbosity": 1},
                      criterions=None,
                      val_freq=1,
                      ** kwargs):
@@ -125,6 +130,50 @@ if "TORCH" in get_backends():
                 whether to use mixed precision or not (False per default)
             mixed_precision_kwargs : dict
                 additional keyword arguments for mixed precision
+                from https://github.com/NVIDIA/apex/blob/master/apex/amp/frontend.py:
+                    opt_level : str
+                        Pure or mixed precision optimization level. Accepted
+                        values are "O0", "O1", "O2", and "O3":
+                            O0:  Pure FP32 training.
+                            O1:  Insert automatic casts around Pytorch functions
+                                and Tensor methods.
+                            O2:  FP16 training with FP32 batchnorm and FP32
+                                master weights
+                            O3:  Pure FP16 training.
+
+                    cast_model_type : :class:`torch.dtype`
+                        Optional property override for model dtype;
+                        default: None
+                    patch_torch_functions : bool
+                        Optional property override.
+                    keep_batchnorm_fp32 : bool or str
+                        Optional property override.  If passed as a string,
+                        must be the string "True" or "False".
+                    master_weights : bool
+                        Optional property override; whether to create master
+                        weights or not
+                    loss_scale : float or str
+                        Optional property override.  If passed as a string,
+                        must be a string representing a number, e.g., "128.0",
+                        or the string "dynamic".
+                    cast_model_outputs : :class:`torch.dtype`
+                        Option to ensure that the outputs of your model(s)
+                        are always cast to a particular type regardless
+                        of ``opt_level``.
+                    num_losses : int
+                        Option to tell Amp in advance how many losses/backward
+                        passes you plan to use.  When used in conjunction with
+                        the ``loss_id`` argument to ``amp.scale_loss``, enables
+                        Amp to use a different loss scale per loss/backward
+                        pass, which can improve stability. See
+                        "Multiple models/optimizers/losses" under
+                        "Advanced Amp Usage" for examples.  If ``num_losses``
+                        is left to 1, Amp will still support multiple
+                        losses/backward passes, but use a single global
+                        loss scale for all of them; default: 1
+                    verbosity : int
+                        Set to 0 to suppress Amp-related output; default: 1
+
             val_freq : int
                 validation frequency specifying how often to validate the
                 trained model (a value of 1 denotes validating every epoch,
@@ -206,25 +255,6 @@ if "TORCH" in get_backends():
                            gpu_ids, key_mapping, convert_batch_to_npy_fn,
                            network.prepare_batch)
 
-            try:
-                from apex import amp
-                self._amp_handle = amp.init(mixed_precision,
-                                            *mixed_precision_kwargs)
-                wrap_fn = self._amp_handle.wrap_optimizer
-
-            except ImportError:
-                if mixed_precision:
-                    logger.warning("Apex was not found found, trying to \
-                                    continue in full precision instead")
-                from ..utils.context_managers import DefaultOptimWrapperTorch
-                wrap_fn = DefaultOptimWrapperTorch
-
-            # wrap optimizers by half_precision_optimizer via apex if
-            # necessary
-            self.optimizers = {k: wrap_fn(
-                v, num_loss=len(self.losses)) for k, v
-                in self.optimizers.items()}
-
             # Load latest epoch file if available
             if os.path.isdir(self.save_path):
                 latest_state_path, latest_epoch = self._search_for_prev_state(
@@ -275,6 +305,28 @@ if "TORCH" in get_backends():
             self._prepare_batch = partial(
                 self._prepare_batch, input_device=self.input_device,
                 output_device=self.output_device)
+
+            try:
+                # use apex for mixed precision if installed
+                from apex import amp
+
+                # extract optimizers and corresponding keys
+                # (in case dict is not ordered)
+                _optim_keys = list(self.optimizers.keys())
+                _optims = list(self.optimizers[k] for k in _optim_keys)
+
+                # wrap model and register optimizers for mixed precision
+                self.module, _optims = amp.initialize(self.module, _optims,
+                                                      mixed_precision,
+                                                      **mixed_precision_kwargs)
+                for k, v in zip(_optim_keys, _optims):
+                    self.optimizers[k] = v
+
+            except (ImportError, RuntimeError) as e:
+                logging.debug("Either APEX can't be imported correctly or a value "
+                              "missmatch occured. Switching to default FP32 "
+                              "training insted. The following Exception occured:"
+                              "\n%s" % str(e))
 
         def _at_training_begin(self, *args, **kwargs):
             """

--- a/delira/training/pytorch_trainer.py
+++ b/delira/training/pytorch_trainer.py
@@ -57,7 +57,7 @@ if "TORCH" in get_backends():
                      metric_keys=None,
                      convert_batch_to_npy_fn=convert_torch_tensor_to_npy,
                      mixed_precision=False,
-                     mixed_precision_kwargs={"opt_level": "o0",
+                     mixed_precision_kwargs={"opt_level": "o1",
                                              "cast_model_type": None,
                                              "patch_torch_functions": None,
                                              "master_weights": None,

--- a/delira/training/pytorch_trainer.py
+++ b/delira/training/pytorch_trainer.py
@@ -323,10 +323,12 @@ if "TORCH" in get_backends():
                     self.optimizers[k] = v
 
             except (ImportError, RuntimeError) as e:
-                logging.debug("Either APEX can't be imported correctly or a value "
-                              "missmatch occured. Switching to default FP32 "
-                              "training insted. The following Exception occured:"
-                              "\n%s" % str(e))
+                logging.debug(
+                    "Either APEX can't be imported correctly or a value "
+                    "missmatch occured. Switching to default FP32 "
+                    "training insted. The following Exception occured:"
+                    "\n%s" %
+                    str(e))
 
         def _at_training_begin(self, *args, **kwargs):
             """

--- a/delira/training/sklearn_trainer.py
+++ b/delira/training/sklearn_trainer.py
@@ -1,0 +1,396 @@
+import os
+import logging
+import numpy as np
+from tqdm.auto import tqdm
+from ..data_loading.sampler import RandomSampler, RandomSamplerNoReplacement
+from .base_trainer import BaseNetworkTrainer
+from ..data_loading import BaseDataManager
+from functools import partial
+
+from delira import get_backends
+
+logger = logging.getLogger(__name__)
+
+if "SKLEARN" in get_backends():
+    from .train_utils import convert_batch_to_numpy_identity
+    from .train_utils import create_empty_optim_dict as create_optims_default
+    from ..io.sklearn import save_checkpoint, load_checkpoint
+    from ..models import SklearnEstimator
+
+    class SklearnEstimatorTrainer(BaseNetworkTrainer):
+        """
+        Train and Validate a Network
+
+        See Also
+        --------
+        :class:`AbstractNetwork`
+
+        """
+
+        def __init__(self,
+                     estimator: SklearnEstimator,
+                     save_path: str,
+                     key_mapping,
+                     train_metrics={},
+                     val_metrics={},
+                     save_freq=1,
+                     logging_type="tensorboardx",
+                     logging_kwargs={},
+                     fold=0,
+                     callbacks=[],
+                     start_epoch=1,
+                     metric_keys=None,
+                     convert_batch_to_npy_fn=convert_batch_to_numpy_identity,
+                     val_freq=1,
+                     ** kwargs):
+            """
+
+            Parameters
+            ----------
+            estimator : :class:`SklearnEstimator`
+                the estimator to train
+            save_path : str
+                path to save networks to
+            key_mapping : dict
+                a dictionary containing the mapping from the ``data_dict`` to
+                the actual model's inputs.
+                E.g. if a model accepts one input named 'x' and the data_dict
+                contains one entry named 'data' this argument would have to
+                be ``{'x': 'data'}``
+            train_metrics : dict, optional
+                metrics, which will be evaluated during train phase
+                (should work on framework's tensor types)
+            val_metrics : dict, optional
+                metrics, which will be evaluated during test phase
+                (should work on numpy arrays)
+            save_freq : int
+                integer specifying how often to save the current model's state.
+                State is saved every state_freq epochs
+            logging_type : str or callable
+                the type of logging. If string: it must be one of
+                ["visdom", "tensorboardx"]
+                If callable: it must be a logging handler class
+            logging_kwargs : dict
+                dictionary containing all logging keyword arguments
+            fold : int
+                current cross validation fold (0 per default)
+            callbacks : list
+                initial callbacks to register
+            start_epoch : int
+                epoch to start training at
+            metric_keys : dict
+                dict specifying which batch_dict entry to use for which metric as
+                target; default: None, which will result in key "label" for all
+                metrics
+            convert_batch_to_npy_fn : type, optional
+                function converting a batch-tensor to numpy, per default this is
+                a function, returning the inputs without changing anything
+            val_freq : int
+                validation frequency specifying how often to validate the trained
+                model (a value of 1 denotes validating every epoch,
+                a value of 2 denotes validating every second epoch etc.);
+                defaults to 1
+            **kwargs :
+                additional keyword arguments
+
+            """
+
+            super().__init__(
+                estimator, save_path, {}, None, None,
+                train_metrics, val_metrics, None,
+                {}, [], save_freq, None, key_mapping,
+                logging_type, logging_kwargs, fold, callbacks, start_epoch,
+                metric_keys, convert_batch_to_npy_fn, val_freq)
+
+            self._setup(estimator,
+                        key_mapping, convert_batch_to_npy_fn)
+
+            for key, val in kwargs.items():
+                setattr(self, key, val)
+
+        def _setup(self, estimator, key_mapping, convert_batch_to_npy_fn):
+            """
+            Defines the Trainers Setup
+
+            Parameters
+            ----------
+            estimator : :class:`SkLearnEstimator`
+                the network to train
+            key_mapping : dict
+                a dictionary containing the mapping from the ``data_dict`` to
+                the actual model's inputs.
+                E.g. if a model accepts one input named 'x' and the data_dict
+                contains one entry named 'data' this argument would have to
+                be ``{'x': 'data'}``
+            convert_batch_to_npy_fn : type
+                function converting a batch-tensor to numpy
+
+            """
+
+            self.optimizers = create_optims_default()
+
+            super()._setup(estimator, None, {},
+                           [], key_mapping, convert_batch_to_npy_fn,
+                           estimator.prepare_batch)
+
+            # Load latest epoch file if available
+            if os.path.isdir(self.save_path):
+                # check all files in directory starting with "checkpoint" and
+                # not ending with "_best.pth"
+                files = [x for x in os.listdir(self.save_path)
+                         if os.path.isfile(os.path.join(self.save_path, x))
+                         and x.startswith("checkpoint")
+                         and not x.endswith("_best.pkl")]
+
+                # if list is not empty: load previous state
+                if files:
+
+                    latest_epoch = max([
+                        int(x.rsplit("_", 1)[-1].rsplit(".", 1)[0])
+                        for x in files])
+
+                    latest_state_path = os.path.join(self.save_path,
+                                                     "checkpoint_epoch_%d.pkl"
+                                                     % latest_epoch)
+
+                    # if pth file does not exist, load pt file instead
+                    if not os.path.isfile(latest_state_path):
+                        latest_state_path = latest_state_path[:-1]
+
+                    logger.info("Attempting to load state from previous \
+                                training from %s" % latest_state_path)
+                    try:
+                        self.update_state(latest_state_path)
+                    except KeyError:
+                        logger.warning("Previous State could not be loaded, \
+                                    although it exists.Training will be \
+                                    restarted")
+            self.use_gpu = False
+            self.input_device = "cpu"
+            self.output_device = "cpu"
+
+            self._prepare_batch = partial(
+                self._prepare_batch, input_device=self.input_device,
+                output_device=self.output_device)
+
+        def _at_training_begin(self, *args, **kwargs):
+            """
+            Defines behaviour at beginning of training
+
+            Parameters
+            ----------
+            *args :
+                positional arguments
+            **kwargs :
+                keyword arguments
+
+            """
+            self.save_state(os.path.join(
+                self.save_path, "checkpoint_epoch_0"), 0)
+
+        def _get_classes_if_necessary(self, dmgr: BaseDataManager, verbose,
+                                      label_key=None):
+            if label_key is None or not hasattr(self.module, "classes"):
+                return
+            dset = dmgr.dataset
+
+            if verbose:
+                iterable = tqdm(enumerate(dset), unit=' sample', total=len(dset),
+                                desc="Creating unique targets to estimate "
+                                     "classes")
+            else:
+                iterable = enumerate(dset)
+
+            unique_targets = []
+            for sample_idx, sample in iterable:
+                item = sample[label_key]
+                if item not in unique_targets:
+                    if np.isscalar(item):
+                        item = np.array([item])
+                    unique_targets.append(item)
+
+            unique_targets = np.concatenate(list(sorted(unique_targets)))
+            self.module.classes = unique_targets
+
+        def train(self, num_epochs, datamgr_train, datamgr_valid=None,
+                  val_score_key=None, val_score_mode='highest',
+                  reduce_mode='mean', verbose=True, label_key="label"):
+            if self.module.train_iterative:
+                # estimate classes from validation data
+                if datamgr_valid is not None:
+                    self._get_classes_if_necessary(datamgr_valid, verbose,
+                                                   label_key)
+                else:
+                    self._get_classes_if_necessary(datamgr_train, verbose,
+                                                   label_key)
+            else:
+                # Setting batchsize to length of dataset and replacing random
+                # sampler with replacement by random sampler without replacement
+                # ensures, that each sample is present in each batch and only
+                # one batch is sampled per epoch
+                datamgr_train.batchsize = len(datamgr_train.dataset)
+                if isinstance(datamgr_train.sampler, RandomSampler):
+                    datamgr_train.sampler = RandomSamplerNoReplacement
+
+                # additionally setting the number of epochs to train ensures,
+                # that only one epoch consisting of one batch (which holds the
+                # whole dataset) is used for training
+                if num_epochs > 1:
+                    logging.info("An epoch number greater than 1 is given, "
+                                 "but the current module does not support "
+                                 "iterative training. Falling back to usual "
+                                 "dataset fitting. For huge datasets, this "
+                                 "might easily result in out of memory errors!")
+                    num_epochs = 1
+
+            return super().train(num_epochs, datamgr_train, datamgr_valid,
+                                 val_score_key, val_score_mode, reduce_mode,
+                                 verbose)
+
+        def _at_training_end(self):
+            """
+            Defines Behaviour at end of training: Loads best model if
+            available
+
+            Returns
+            -------
+            :class:`SkLearnEstimator`
+                best network
+
+            """
+            if os.path.isfile(os.path.join(self.save_path,
+                                           'checkpoint_best.pkl')):
+
+                # load best model and return it
+                self.update_state(os.path.join(self.save_path,
+                                               'checkpoint_best.pkl'))
+
+            return self.module
+
+        def _at_epoch_end(self, metrics_val, val_score_key, epoch, is_best,
+                          **kwargs):
+            """
+            Defines behaviour at beginning of each epoch: Executes all callbacks's
+            `at_epoch_end` method and saves current state if necessary
+
+            Parameters
+            ----------
+            metrics_val : dict
+                validation metrics
+            val_score_key : str
+                validation score key
+            epoch : int
+                current epoch
+            num_epochs : int
+                total number of epochs
+            is_best : bool
+                whether current model is best one so far
+            **kwargs :
+                keyword arguments
+
+            """
+
+            for cb in self._callbacks:
+                self._update_state(cb.at_epoch_end(self, val_metrics=metrics_val,
+                                                   val_score_key=val_score_key,
+                                                   curr_epoch=epoch))
+
+            if epoch % self.save_freq == 0:
+                self.save_state(os.path.join(self.save_path,
+                                             "checkpoint_epoch_%d.pkl" % epoch),
+                                epoch)
+
+            if is_best:
+                self.save_state(os.path.join(self.save_path,
+                                             "checkpoint_best.pkl"),
+                                epoch)
+
+        def save_state(self, file_name, epoch, **kwargs):
+            """
+            saves the current state via
+            :func:`delira.io.sklearn.save_checkpoint`
+
+            Parameters
+            ----------
+            file_name : str
+                filename to save the state to
+            epoch : int
+                current epoch (will be saved for mapping back)
+            *args :
+                positional arguments
+            **kwargs :
+                keyword arguments
+
+            """
+            if not file_name.endswith(".pkl"):
+                file_name = file_name + ".pkl"
+            save_checkpoint(file_name, self.module, epoch, **kwargs)
+
+        @staticmethod
+        def load_state(file_name, *args, **kwargs):
+            """
+            Loads the new state from file via
+            :func:`delira.io.sklearn.load_checkpoint`
+
+            Parameters
+            ----------
+            file_name : str
+                the file to load the state from
+            **kwargs : keyword arguments
+
+            Returns
+            -------
+            dict
+                new state
+
+            """
+
+            if not file_name.endswith(".pkl"):
+                file_name = file_name + ".pkl"
+
+            return load_checkpoint(file_name, **kwargs)
+
+        def update_state(self, file_name, *args, **kwargs):
+            """
+            Update internal state from a loaded state
+
+            Parameters
+            ----------
+            file_name : str
+                file containing the new state to load
+            *args :
+                positional arguments
+            **kwargs :
+                keyword arguments
+
+            Returns
+            -------
+            :class:`SkLearnEstimatorTrainer`
+                the trainer with a modified state
+
+            """
+            self._update_state(self.load_state(file_name, *args, **kwargs))
+
+        def _update_state(self, new_state):
+            """
+            Update the state from a given new state
+
+            Parameters
+            ----------
+            new_state : dict
+                new state to update internal state from
+
+            Returns
+            -------
+            :class:`SkLearnEstimatorTrainer`
+                the trainer with a modified state
+
+            """
+
+            if "model" in new_state:
+                self.module = new_state.pop("model")
+
+            if "epoch" in new_state:
+                self.start_epoch = new_state.pop("epoch")
+
+            return super()._update_state(new_state)

--- a/delira/training/sklearn_trainer.py
+++ b/delira/training/sklearn_trainer.py
@@ -192,9 +192,8 @@ if "SKLEARN" in get_backends():
             dset = dmgr.dataset
 
             if verbose:
-                iterable = tqdm(enumerate(dset), unit=' sample', total=len(dset),
-                                desc="Creating unique targets to estimate "
-                                     "classes")
+                iterable = tqdm(enumerate(dset), unit=' sample', total=len(
+                    dset), desc="Creating unique targets to estimate " "classes")
 
             else:
                 iterable = enumerate(dset)

--- a/delira/training/sklearn_trainer.py
+++ b/delira/training/sklearn_trainer.py
@@ -96,7 +96,7 @@ if "SKLEARN" in get_backends():
             """
 
             super().__init__(
-                estimator, save_path, {}, None, None,
+                estimator, save_path, {}, None, {},
                 train_metrics, val_metrics, None,
                 {}, [], save_freq, None, key_mapping,
                 logging_type, logging_kwargs, fold, callbacks, start_epoch,
@@ -215,7 +215,7 @@ if "SKLEARN" in get_backends():
         def train(self, num_epochs, datamgr_train, datamgr_valid=None,
                   val_score_key=None, val_score_mode='highest',
                   reduce_mode='mean', verbose=True, label_key="label"):
-            if self.module.train_iterative:
+            if self.module.iterative_training:
                 # estimate classes from validation data
                 if datamgr_valid is not None:
                     self._get_classes_if_necessary(datamgr_valid, verbose,

--- a/delira/training/sklearn_trainer.py
+++ b/delira/training/sklearn_trainer.py
@@ -210,9 +210,8 @@ if "SKLEARN" in get_backends():
             dset = dmgr.dataset
 
             if verbose:
-                iterable = tqdm(enumerate(dset), unit=' sample', total=len(dset),
-                                desc="Creating unique targets to estimate "
-                                     "classes")
+                iterable = tqdm(enumerate(dset), unit=' sample', total=len(
+                    dset), desc="Creating unique targets to estimate " "classes")
             else:
                 iterable = enumerate(dset)
 
@@ -286,11 +285,12 @@ if "SKLEARN" in get_backends():
                 # that only one epoch consisting of one batch (which holds the
                 # whole dataset) is used for training
                 if num_epochs > 1:
-                    logging.info("An epoch number greater than 1 is given, "
-                                 "but the current module does not support "
-                                 "iterative training. Falling back to usual "
-                                 "dataset fitting. For huge datasets, this "
-                                 "might easily result in out of memory errors!")
+                    logging.info(
+                        "An epoch number greater than 1 is given, "
+                        "but the current module does not support "
+                        "iterative training. Falling back to usual "
+                        "dataset fitting. For huge datasets, this "
+                        "might easily result in out of memory errors!")
                     num_epochs = 1
 
             return super().train(num_epochs, datamgr_train, datamgr_valid,
@@ -341,14 +341,20 @@ if "SKLEARN" in get_backends():
             """
 
             for cb in self._callbacks:
-                self._update_state(cb.at_epoch_end(self, val_metrics=metrics_val,
-                                                   val_score_key=val_score_key,
-                                                   curr_epoch=epoch))
+                self._update_state(
+                    cb.at_epoch_end(
+                        self,
+                        val_metrics=metrics_val,
+                        val_score_key=val_score_key,
+                        curr_epoch=epoch))
 
             if epoch % self.save_freq == 0:
-                self.save_state(os.path.join(self.save_path,
-                                             "checkpoint_epoch_%d.pkl" % epoch),
-                                epoch)
+                self.save_state(
+                    os.path.join(
+                        self.save_path,
+                        "checkpoint_epoch_%d.pkl" %
+                        epoch),
+                    epoch)
 
             if is_best:
                 self.save_state(os.path.join(self.save_path,

--- a/delira/training/sklearn_trainer.py
+++ b/delira/training/sklearn_trainer.py
@@ -205,6 +205,7 @@ if "SKLEARN" in get_backends():
                 the key corresponding to the target value inside the data dict
 
             """
+
             if label_key is None or not hasattr(self.module, "classes"):
                 return
             dset = dmgr.dataset
@@ -266,6 +267,7 @@ if "SKLEARN" in get_backends():
 
             """
             if self.module.iterative_training:
+
                 # estimate classes from validation data
                 if datamgr_valid is not None:
                     self._get_classes_if_necessary(datamgr_valid, verbose,

--- a/delira/training/tf_trainer.py
+++ b/delira/training/tf_trainer.py
@@ -600,4 +600,5 @@ class TfEagerNetworkTrainer(BaseNetworkTrainer):
         -------
 
         """
-        return tf_eager_load_checkpoint(file_name, self.module, self.optimizers)
+        return tf_eager_load_checkpoint(
+            file_name, self.module, self.optimizers)

--- a/delira/training/train_utils.py
+++ b/delira/training/train_utils.py
@@ -4,6 +4,10 @@ from ..utils.decorators import dtype_func
 from delira import get_backends
 
 
+def create_empty_optim_dict(*args, **kwargs):
+    return {}
+
+
 def _check_and_correct_zero_shape(arg):
     """
     Corrects the shape of numpy array to be at least 1d and returns the

--- a/delira/training/train_utils.py
+++ b/delira/training/train_utils.py
@@ -4,6 +4,10 @@ from delira import get_backends
 from ..utils.decorators import dtype_func
 
 
+def create_empty_optim_dict(*args, **kwargs):
+    return {}
+
+
 def _check_and_correct_zero_shape(arg):
     """
     Corrects the shape of numpy array to be at least 1d and returns the

--- a/delira/utils/config.py
+++ b/delira/utils/config.py
@@ -64,7 +64,7 @@ class LookupConfig(Config):
 
         """
 
-        if type(value) == dict or type(value) == Config:
+        if isinstance(value, dict) or isinstance(value, Config):
             update_val = LookupConfig()
             update_val.update(value, deep=False)
         else:

--- a/delira/utils/context_managers.py
+++ b/delira/utils/context_managers.py
@@ -13,9 +13,14 @@ if "TORCH" in get_backends():
 
         """
 
+<<<<<<< HEAD
         @make_deprecated(
             "'delira.models.model_utils.scale_loss' combined with "
             "new apex.amp API (https://github.com/NVIDIA/apex)")
+=======
+        @make_deprecated("'delira.models.model_utils.scale_loss' combined with "
+                         "new apex.amp API (https://github.com/NVIDIA/apex)")
+>>>>>>> Move to new APEX.amp API
         def __init__(self, optimizer: torch.optim.Optimizer, *args, **kwargs):
             """
 

--- a/delira/utils/context_managers.py
+++ b/delira/utils/context_managers.py
@@ -13,8 +13,9 @@ if "TORCH" in get_backends():
 
         """
 
-        @make_deprecated("'delira.models.model_utils.scale_loss' combined with "
-                         "new apex.amp API (https://github.com/NVIDIA/apex)")
+        @make_deprecated(
+            "'delira.models.model_utils.scale_loss' combined with "
+            "new apex.amp API (https://github.com/NVIDIA/apex)")
         def __init__(self, optimizer: torch.optim.Optimizer, *args, **kwargs):
             """
 

--- a/delira/utils/context_managers.py
+++ b/delira/utils/context_managers.py
@@ -1,6 +1,7 @@
 import contextlib
 
 from delira import get_backends
+from .decorators import make_deprecated
 
 if "TORCH" in get_backends():
     import torch
@@ -12,6 +13,8 @@ if "TORCH" in get_backends():
 
         """
 
+        @make_deprecated("'delira.models.model_utils.scale_loss' combined with "
+                         "new apex.amp API (https://github.com/NVIDIA/apex)")
         def __init__(self, optimizer: torch.optim.Optimizer, *args, **kwargs):
             """
 

--- a/tests/models/test_models_torch.py
+++ b/tests/models/test_models_torch.py
@@ -89,37 +89,50 @@ class TorchModelTest(unittest.TestCase):
         for case in test_cases:
             with self.subTest(case=case):
 
+                mixed_prec = False
+
                 model, input_shape, output_shape, loss_fn, optim_fn, \
                     max_range, half_precision = case
-
-                try:
-                    from apex import amp
-                    amp_handle = amp.init(half_precision)
-                    wrapper_fn = amp_handle.wrap_optimizer
-                except ImportError:
-                    wrapper_fn = DefaultOptimWrapperTorch
 
                 start_time = time.time()
 
                 # test backward if optimizer fn is not None
                 if optim_fn is not None:
-                    optim = {k: wrapper_fn(v, num_loss=len(loss_fn))
-                             for k, v in optim_fn(model,
-                                                  torch.optim.Adam).items()}
+                    optim = optim_fn(model, torch.optim.Adam)
 
                 else:
                     optim = {}
 
                 closure = model.closure
                 device = torch.device("cpu")
+
+                if torch.cuda.is_available():
+                    device = torch.device("cuda")
+                    # only enable mixed precision on cuda
+                    mixed_prec = True
+
                 model = model.to(device)
                 prepare_batch = model.prepare_batch
+
+                try:
+                    from apex import amp
+                    _optim_keys = list(optim.keys())
+                    _optims = [optim[k] for k in _optim_keys]
+
+                    model, _optims = amp.initialize(model, _optims,
+                                                    enabled=mixed_prec,
+                                                    opt_level="O1")
+
+                    for k, v in zip(_optim_keys, optim):
+                        optim[k] = v
+
+                except ImportError:
+                    amp = None
 
                 # classification label: target_shape specifies max label
                 if isinstance(output_shape, int):
                     label = np.asarray([np.random.randint(output_shape)
-                                        for i in range(
-                        10)])
+                                        for i in range(10)])
                 else:
                     label = np.random.rand(10, *output_shape) * max_range
 
@@ -145,10 +158,7 @@ class TorchModelTest(unittest.TestCase):
                 del closure
                 del prepare_batch
                 del model
-                try:
-                    del amp_handle
-                except NameError:
-                    pass
+                del amp
                 gc.collect()
 
 

--- a/tests/training/test_experiments.py
+++ b/tests/training/test_experiments.py
@@ -158,11 +158,11 @@ class ExperimentTest(unittest.TestCase):
                         "val_metrics": {"mae": mean_absolute_error}
                     }
                 }),
-                 500,
-                 50,
-                 "mae",
-                 "lowest",
-                 DecisionTreeClassifier
+                    500,
+                    50,
+                    "mae",
+                    "lowest",
+                    DecisionTreeClassifier
                 ))
 
             test_cases_sklearn.append(
@@ -173,11 +173,11 @@ class ExperimentTest(unittest.TestCase):
                         "val_metrics": {"mae": mean_absolute_error}
                     }
                 }),
-                 500,
-                 50,
-                 "mae",
-                 "lowest",
-                 MLPClassifier
+                    500,
+                    50,
+                    "mae",
+                    "lowest",
+                    MLPClassifier
                 ))
 
             self._test_cases_sklearn = test_cases_sklearn

--- a/tests/training/test_experiments.py
+++ b/tests/training/test_experiments.py
@@ -28,7 +28,9 @@ class DummyDataset(AbstractDataset):
 class ExperimentTest(unittest.TestCase):
 
     def setUp(self) -> None:
-        test_cases_torch, test_cases_torchscript, test_cases_tf = [], [], []
+
+        test_cases_torch, test_cases_tf, test_cases_sklearn, test_cases_torchscript = [], [], [], []
+
         from sklearn.metrics import mean_absolute_error
 
         # setup torch testcases
@@ -196,6 +198,42 @@ class ExperimentTest(unittest.TestCase):
             )
 
         self._test_cases_tf = test_cases_tf
+
+        if "SKLEARN" in get_backends():
+            from sklearn.tree import DecisionTreeClassifier
+            from sklearn.neural_network import MLPClassifier
+
+            test_cases_sklearn.append(
+                (Parameters(fixed_params={
+                    "model": {},
+                    "training": {
+                        "num_epochs": 2,
+                        "val_metrics": {"mae": mean_absolute_error}
+                    }
+                }),
+                 500,
+                 50,
+                 "mae",
+                 "lowest",
+                 DecisionTreeClassifier
+                ))
+
+            test_cases_sklearn.append(
+                (Parameters(fixed_params={
+                    "model": {},
+                    "training": {
+                        "num_epochs": 2,
+                        "val_metrics": {"mae": mean_absolute_error}
+                    }
+                }),
+                 500,
+                 50,
+                 "mae",
+                 "lowest",
+                 MLPClassifier
+                ))
+
+            self._test_cases_sklearn = test_cases_sklearn
 
     @unittest.skipIf("TORCH" not in get_backends(),
                      reason="No TORCH Backend installed")
@@ -534,6 +572,57 @@ class ExperimentTest(unittest.TestCase):
                                     val_split=val_split,
                                     num_splits=2,
                                 )
+
+    @unittest.skipIf("SKLEARN" not in get_backends(),
+                     reason="No SKLEARN Backend installed")
+    def test_experiment_run_sklearn(self):
+
+        from delira.training import SkLearnExperiment
+        from delira.data_loading import BaseDataManager
+
+        for case in self._test_cases_sklearn:
+            with self.subTest(case=case):
+                (params, dataset_length_train, dataset_length_test,
+                 val_score_key, val_score_mode, network_cls) = case
+
+                exp = SkLearnExperiment(params, network_cls,
+                                        key_mapping={"X": "X"},
+                                        val_score_key=val_score_key,
+                                        val_score_mode=val_score_mode)
+
+                dset_train = DummyDataset(dataset_length_train)
+                dset_test = DummyDataset(dataset_length_test)
+
+                dmgr_train = BaseDataManager(dset_train, 16, 4, None)
+                dmgr_test = BaseDataManager(dset_test, 16, 1, None)
+
+                exp.run(dmgr_train, dmgr_test)
+
+    @unittest.skipIf("SKLEARN" not in get_backends(),
+                     reason="No SKLEARN Backend installed")
+    def test_experiment_test_sklearn(self):
+        from delira.training import SkLearnExperiment
+        from delira.data_loading import BaseDataManager
+
+        for case in self._test_cases_sklearn:
+            with self.subTest(case=case):
+                (params, dataset_length_train, dataset_length_test,
+                 val_score_key, val_score_mode, network_cls) = case
+
+                exp = SkLearnExperiment(params, network_cls,
+                                        key_mapping={"X": "data"},
+                                        val_score_key=val_score_key,
+                                        val_score_mode=val_score_mode)
+                model = network_cls()
+
+                # must fit on 2 samples to initialize coefficients
+                model.fit(np.random.rand(2, 32), np.array([[0], [1]]))
+
+                dset_test = DummyDataset(dataset_length_test)
+                dmgr_test = BaseDataManager(dset_test, 16, 1, None)
+
+                exp.test(model, dmgr_test,
+                         params.nested_get("val_metrics"))
 
 
 if __name__ == '__main__':

--- a/tests/training/test_experiments.py
+++ b/tests/training/test_experiments.py
@@ -306,11 +306,11 @@ class ExperimentTest(unittest.TestCase):
                         "val_metrics": {"mae": mean_absolute_error}
                     }
                 }),
-                 500,
-                 50,
-                 "mae",
-                 "lowest",
-                 DecisionTreeClassifier
+                    500,
+                    50,
+                    "mae",
+                    "lowest",
+                    DecisionTreeClassifier
                 ))
 
             test_cases["sklearn"].append(
@@ -321,15 +321,14 @@ class ExperimentTest(unittest.TestCase):
                         "val_metrics": {"mae": mean_absolute_error}
                     }
                 }),
-                 500,
-                 50,
-                 "mae",
-                 "lowest",
-                 MLPClassifier
+                    500,
+                    50,
+                    "mae",
+                    "lowest",
+                    MLPClassifier
                 ))
 
         self._test_cases = test_cases
-
 
     @unittest.skipIf("TORCH" not in get_backends(),
                      reason="No TORCH Backend installed")
@@ -613,14 +612,12 @@ class ExperimentTest(unittest.TestCase):
                                     num_splits=2,
                                 )
 
-
     @unittest.skipIf("TF" not in get_backends(),
                      reason="No TF Backend installed")
     def test_experiment_run_tf_eager(self):
 
         from delira.training import TfEagerExperiment
         from delira.data_loading import BaseDataManager
-
 
         for case in self._test_cases["tf_eager"]:
             with self.subTest(case=case):
@@ -652,7 +649,7 @@ class ExperimentTest(unittest.TestCase):
 
                 exp = TfEagerExperiment(params, network_cls,
                                         key_mapping={"x": "data"}
-                                       )
+                                        )
 
                 model = network_cls()
 

--- a/tests/training/test_experiments.py
+++ b/tests/training/test_experiments.py
@@ -28,7 +28,7 @@ class DummyDataset(AbstractDataset):
 class ExperimentTest(unittest.TestCase):
 
     def setUp(self) -> None:
-        test_cases_torch, test_cases_tf = [], []
+        test_cases_torch, test_cases_tf, test_cases_sklearn = [], [], []
         from sklearn.metrics import mean_absolute_error
 
         # setup torch testcases
@@ -145,6 +145,42 @@ class ExperimentTest(unittest.TestCase):
             )
 
         self._test_cases_tf = test_cases_tf
+
+        if "SKLEARN" in get_backends():
+            from sklearn.tree import DecisionTreeClassifier
+            from sklearn.neural_network import MLPClassifier
+
+            test_cases_sklearn.append(
+                (Parameters(fixed_params={
+                    "model": {},
+                    "training": {
+                        "num_epochs": 2,
+                        "val_metrics": {"mae": mean_absolute_error}
+                    }
+                }),
+                 500,
+                 50,
+                 "mae",
+                 "lowest",
+                 DecisionTreeClassifier
+                ))
+
+            test_cases_sklearn.append(
+                (Parameters(fixed_params={
+                    "model": {},
+                    "training": {
+                        "num_epochs": 2,
+                        "val_metrics": {"mae": mean_absolute_error}
+                    }
+                }),
+                 500,
+                 50,
+                 "mae",
+                 "lowest",
+                 MLPClassifier
+                ))
+
+            self._test_cases_sklearn = test_cases_sklearn
 
     @unittest.skipIf("TORCH" not in get_backends(),
                      reason="No TORCH Backend installed")
@@ -358,6 +394,57 @@ class ExperimentTest(unittest.TestCase):
                                           shuffle=True, split_type=split_type,
                                           val_split=val_split, num_splits=2,
                                           )
+
+    @unittest.skipIf("SKLEARN" not in get_backends(),
+                     reason="No SKLEARN Backend installed")
+    def test_experiment_run_sklearn(self):
+
+        from delira.training import SkLearnExperiment
+        from delira.data_loading import BaseDataManager
+
+        for case in self._test_cases_sklearn:
+            with self.subTest(case=case):
+                (params, dataset_length_train, dataset_length_test,
+                 val_score_key, val_score_mode, network_cls) = case
+
+                exp = SkLearnExperiment(params, network_cls,
+                                        key_mapping={"X": "X"},
+                                        val_score_key=val_score_key,
+                                        val_score_mode=val_score_mode)
+
+                dset_train = DummyDataset(dataset_length_train)
+                dset_test = DummyDataset(dataset_length_test)
+
+                dmgr_train = BaseDataManager(dset_train, 16, 4, None)
+                dmgr_test = BaseDataManager(dset_test, 16, 1, None)
+
+                exp.run(dmgr_train, dmgr_test)
+
+    @unittest.skipIf("SKLEARN" not in get_backends(),
+                     reason="No SKLEARN Backend installed")
+    def test_experiment_test_sklearn(self):
+        from delira.training import SkLearnExperiment
+        from delira.data_loading import BaseDataManager
+
+        for case in self._test_cases_sklearn:
+            with self.subTest(case=case):
+                (params, dataset_length_train, dataset_length_test,
+                 val_score_key, val_score_mode, network_cls) = case
+
+                exp = SkLearnExperiment(params, network_cls,
+                                        key_mapping={"X": "data"},
+                                        val_score_key=val_score_key,
+                                        val_score_mode=val_score_mode)
+                model = network_cls()
+
+                # must fit on 2 samples to initialize coefficients
+                model.fit(np.random.rand(2, 32), np.array([[0], [1]]))
+
+                dset_test = DummyDataset(dataset_length_test)
+                dmgr_test = BaseDataManager(dset_test, 16, 1, None)
+
+                exp.test(model, dmgr_test,
+                         params.nested_get("val_metrics"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR aims to add a wrapper for `sklearn`to add compatibility with `delira`.

This is especially useful, if one wants to compare non-deep methods with neural networks (and `sklearn` also offers deep learning modules), because it enables the re-usability of  entire pipeline by simply switching out some classes.

The wrapper is implemented in a way, that it allows training for iterative approaches as neural networks (via `partial_fit`) as well as non-iterative approaches such as KNNs or Decision Trees (via `fit`).

Tests for Sklearn backend are passing, the only tests failing are the tf tests from #66 which aren't relevant for this PR.

This PR should be merged after #66 #98 and #101 have been merged.

Remaining ToDos (will be done, once there are no other changes requested by the reviewers and all previous PRs were merged) :
- [x] Add backend to Setup.py

- [ ] Add backend to README.md

- [ ] Add backend to getting started section of docs

- [ ] Add simple example