### PR TITLE
tensorflow to 1.14

### DIFF
--- a/requirements_extra_tf.txt
+++ b/requirements_extra_tf.txt
@@ -1,3 +1,3 @@
-tensorflow-gpu==1.13.1
+tensorflow-gpu==1.14
 # use trixi-slim >= 0.1.2.1 for tensorboardX support
 trixi-slim>0.1.2.1

--- a/scripts/ci/install_before_tests.sh
+++ b/scripts/ci/install_before_tests.sh
@@ -4,7 +4,7 @@ pip install -U pip wheel;
 pip install -r requirements.txt;
 pip install -r requirements_extra_tf.txt;
 pip uninstall -y tensorflow-gpu;
-pip install tensorflow==1.13.1;
+pip install tensorflow==1.14;
 pip install -r requirements_extra_torch.txt;
 pip install coverage;
 pip install codecov;


### PR DESCRIPTION
Update tensorflow backend version to [1.14](https://github.com/tensorflow/tensorflow/releases/tag/v1.14.0), which does not include breaking changes.