### PR TITLE
Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,3 +45,22 @@
 
 # Utils
 /delira/utils/ @justusschock @mibaumgartner
+
+
+# Global repo stuff
+/* @justusschock
+/docker/ @haarburger
+/docs/ @justusschock
+/notebooks/* @mibaumgartner
+/paper/ @haarburger
+/requirements/ @haarburger @justusschock @mibaumgartner @ORippler
+/scripts/ci/ @justusschock
+
+# Tests
+/tests/* @justusschock
+/tests/data_loading @justusschock @mibaumgartner
+/tests/io/ @justusschock @ORippler
+/logging/ @justusschock @ORippler
+/tests/models/ @justusschock
+/tests/training/* @mibaumgarnter
+/tests/training/backends/ @justusschock

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,47 @@
+# Use this CODEOWNERS file for automatically request reviews from owners at PRs. 
+# For Details see https://help.github.com/en/articles/about-code-owners
+# The order of the codeowners is simply alphabetically. 
+
+# General Namespace (versioning backend resolution etc.)
+/delira/* @justusschock
+
+# DataLoading
+/delira/data_loading/ @justusschock @mibaumgartner
+
+# IO
+/delira/io/ @justusschock
+/delira/io/tf.py @ORippler
+
+# Logging
+/delira/logging/ @justusschock @ORippler
+
+# Models
+/delira/models/* @justusschock
+/delira/models/backends/* @justusschock
+/delira/models/backends/chainer/ @justusschock
+/delira/models/backends/sklearn/ @justusschock
+/delira/models/backends/tf_eager/ @justusschock @ORippler
+/delira/models/backends/tf_graph/ @ORippler
+/delira/models/backends/torch/ @justusschock @mibaumgartner
+/delira/models/backends/torchscript/ @justusschock
+
+# Training
+/delira/training/__init__.py @justusschock
+/delira/training/base_experiment.py @justusschock @mibaumgartner @ORippler
+/delira/training/base_trainer.py @justusschock @mibaumgartner @ORippler
+/delira/training/losses.py @mibaumgartner
+/delira/training/metrics.py @justusschock @mibaumgartner
+/delira/training/parameters.py @justusschock @mibaumgartner
+/delira/training/predictor.py @justusschock @mibaumgartner @ORippler
+/delira/training/utils.py @justusschock
+/delira/training/backends/* @justusschock
+/delira/training/backends/chainer/ @justusschock
+/delira/training/backends/sklearn/ @justusschock
+/delira/training/backends/tf_eager/ @justusschock @ORippler
+/delira/training/backends/tf_graph/ @ORippler
+/delira/taining/backends/torch/ @justusschock @mibaumgartner
+/delira/training/backends/torchscript/ @justusschock
+/delira/training/callbacks/ @justusschock
+
+# Utils
+/delira/utils/ @justusschock @mibaumgartner


### PR DESCRIPTION
Since this Repo becomes more and more complex, a `CODEOWNERS` makes it easier to request a PR from the correct person (the owner of the code you're working on). The order of the owners is purely alphabetic!

It should be merged after #102 

EDIT: since this branch is based on #102 , only the commits starting at f50e7fb are relevant for reviewing