### PR TITLE
Travis fix

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ tqdm
 visdom>=0.1.8.5
 pyyaml
 trixi-slim>0.1.2.1
-batchgenerators>=0.18.2,!=0.19.2,<19.4
+batchgenerators>=0.18.2,!=0.19.2,<0.19.4
 tensorboardX
 psutil
 nested_lookup

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ tqdm
 visdom>=0.1.8.5
 pyyaml
 trixi-slim>0.1.2.1
-batchgenerators>=0.18.2,!=0.19.2
+batchgenerators>=0.18.2,!=0.19.2,<19.4
 tensorboardX
 psutil
 nested_lookup


### PR DESCRIPTION
This PR constrains the `batchgenerators` dependency to versions lower than 0.19.4 (these are the versions we now to work) to avoid slowing down the ci/cd beyond uselessness.

The actual issue is tracked at https://github.com/MIC-DKFZ/batchgenerators/issues/44. 