### PR TITLE
remove globalstep from logging

### DIFF
--- a/delira/training/callbacks/logging_callback.py
+++ b/delira/training/callbacks/logging_callback.py
@@ -76,12 +76,10 @@ class DefaultLoggingCallback(AbstractCallback):
         """
 
         metrics = kwargs.get("metrics", {})
-        global_step = kwargs.get("global_iter_num", None)
 
         for k, v in metrics.items():
             self._logger.log({"scalar": {"tag": self.create_tag(k, train),
-                                         "scalar_value": v,
-                                         "global_step": global_step}})
+                                         "scalar_value": v}})
 
         return {}
 


### PR DESCRIPTION
Global step is also increased during validation which leads to funny looking skips in logging.
![image](https://user-images.githubusercontent.com/18682218/66502003-c3254500-eac4-11e9-9bdd-b13f42641a82.png)
