### PR TITLE
Fixed logging problems

### DIFF
--- a/delira/logging/base_backend.py
+++ b/delira/logging/base_backend.py
@@ -151,7 +151,7 @@ class BaseBackend(object, metaclass=ABCMeta):
 
         """
         # get item from dict
-        process_item = self._queue.get(timeout=0.5)
+        process_item = self._queue.get(timeout=0.001)
         # log item if item is dict
         if isinstance(process_item, dict):
 

--- a/delira/utils/dict_reductions.py
+++ b/delira/utils/dict_reductions.py
@@ -205,7 +205,11 @@ def reduce_dict(items: list, reduce_fn) -> dict:
 
     for k, v in result_dict.items():
         # check if all items are equal
-        if all([_v == v[0] for _v in v[1:]]):
+        equals = [_v == v[0] for _v in v[1:]]
+        for idx, equality in enumerate(equals):
+            if isinstance(equality, np.ndarray):
+                equals[idx] = equality.all()
+        if all(equals):
             # use first item since they are equal
             result_dict[k] = v[0]
         else:


### PR DESCRIPTION
A logging frequency of 2 or more will cause long waiting times: Fixed
Comparing images caused an error: Fixed

Closes #230 